### PR TITLE
Update absolute links for SPA2018 and SPA2019

### DIFF
--- a/spa2018/programme.html
+++ b/spa2018/programme.html
@@ -5,34 +5,34 @@
 </li><li class="track-1">
   <h3><span class='time'>09:45  -  11:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session751.html">Behind the AI Curtain - Designing for Trust in Machine Learning Products</a></h4>
+      <h4><a href="/spa2018/sessions/session751.html">Behind the AI Curtain - Designing for Trust in Machine Learning Products</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/crystalyan.html">Crystal Yan</a>
+  <a href="/spa2018/people/crystalyan.html">Crystal Yan</a>
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>09:45  -  11:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session813.html"> Secure Code Development in Practice</a></h4>
+      <h4><a href="/spa2018/sessions/session813.html"> Secure Code Development in Practice</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/tamaralopez.html">Tamara Lopez</a>, The Open University
+  <a href="/spa2018/people/tamaralopez.html">Tamara Lopez</a>, The Open University
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/helensharp.html">Helen Sharp</a>, The Open University
+  <a href="/spa2018/people/helensharp.html">Helen Sharp</a>, The Open University
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/theintun.html">Thein Tun</a>, The Open University
+  <a href="/spa2018/people/theintun.html">Thein Tun</a>, The Open University
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>09:45  -  11:00</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session807.html">Writing slow regexp is easier than you think (and want it to be)</a></h4>
+      <h4><a href="/spa2018/sessions/session807.html">Writing slow regexp is easier than you think (and want it to be)</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/maciejrzasa.html">Maciej Rzasa</a>, TextMaster
+  <a href="/spa2018/people/maciejrzasa.html">Maciej Rzasa</a>, TextMaster
 </li>
 </ul>
     </div>
@@ -41,32 +41,32 @@
 </li><li class="track-1">
   <h3><span class='time'>11:15  -  12:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session791.html">Become a Fantastic Facilitator</a></h4>
+      <h4><a href="/spa2018/sessions/session791.html">Become a Fantastic Facilitator</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/katiec.html">Katie Coleman</a>, FutureLearn
+  <a href="/spa2018/people/katiec.html">Katie Coleman</a>, FutureLearn
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/traceywalker.html">Tracey  Walker</a>, FutureLearn
+  <a href="/spa2018/people/traceywalker.html">Tracey  Walker</a>, FutureLearn
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>11:15  -  12:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session768.html">You Too Can Be A Sketching Machine!</a></h4>
+      <h4><a href="/spa2018/sessions/session768.html">You Too Can Be A Sketching Machine!</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/rizwanjavaid.html">Rizwan Javaid</a>, Slalom Consulting
+  <a href="/spa2018/people/rizwanjavaid.html">Rizwan Javaid</a>, Slalom Consulting
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>11:15  -  12:30</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session781.html">How to hack your own apps!</a></h4>
+      <h4><a href="/spa2018/sessions/session781.html">How to hack your own apps!</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/tanyajanca.html">Tanya Janca</a>, Microsoft
+  <a href="/spa2018/people/tanyajanca.html">Tanya Janca</a>, Microsoft
 </li>
 </ul>
     </div>
@@ -75,7 +75,7 @@
 </li><li class="all-tracks">
   <h3><span class='time'>13:30  -  14:30</span></h3>
   <div>
-    <h4><a href="https://spaconference.org/spa2018/announcements/keynotes/2018/04/10/alicia-keynote.html">Keynote</a></h4>
+    <h4><a href="/spa2018/announcements/keynotes/2018/04/10/alicia-keynote.html">Keynote</a></h4>
     <ul><li>Alicia Carr</li></ul>
   </div>
 </li><li class="all-tracks break">
@@ -83,34 +83,34 @@
 </li><li class="track-1">
   <h3><span class='time'>14:45  -  16:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session747.html">More Than Music with MIDI, JavaScript &amp; Tiny Computers</a></h4>
+      <h4><a href="/spa2018/sessions/session747.html">More Than Music with MIDI, JavaScript &amp; Tiny Computers</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/georgemandis.html">George Mandis</a>, SnapTortoise
+  <a href="/spa2018/people/georgemandis.html">George Mandis</a>, SnapTortoise
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>14:45  -  16:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session809.html">Typing is not the hard part - Developing a culture of pair programming</a></h4>
+      <h4><a href="/spa2018/sessions/session809.html">Typing is not the hard part - Developing a culture of pair programming</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/thomaslee.html">Thomas Lee</a>, GDS
+  <a href="/spa2018/people/thomaslee.html">Thomas Lee</a>, GDS
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/emmabeynon.html">Emma Beynon</a>, Government Digital Service
+  <a href="/spa2018/people/emmabeynon.html">Emma Beynon</a>, Government Digital Service
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/bevanloon.html">Bevan Loon</a>, Government Digital Service
+  <a href="/spa2018/people/bevanloon.html">Bevan Loon</a>, Government Digital Service
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>14:45  -  16:00</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session822.html">Why Cultivating Observational Skills are so important?</a></h4>
+      <h4><a href="/spa2018/sessions/session822.html">Why Cultivating Observational Skills are so important?</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/mohinderkhosla.html">Mohinder Khosla</a>, Retired
+  <a href="/spa2018/people/mohinderkhosla.html">Mohinder Khosla</a>, Retired
 </li>
 </ul>
     </div>
@@ -119,74 +119,74 @@
 </li><li class="track-1">
   <h3><span class='time'>16:15  -  17:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session747.html">More Than Music with MIDI, JavaScript &amp; Tiny Computers</a></h4>
+      <h4><a href="/spa2018/sessions/session747.html">More Than Music with MIDI, JavaScript &amp; Tiny Computers</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/georgemandis.html">George Mandis</a>, SnapTortoise
+  <a href="/spa2018/people/georgemandis.html">George Mandis</a>, SnapTortoise
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>16:15  -  17:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session809.html">Typing is not the hard part - Developing a culture of pair programming</a></h4>
+      <h4><a href="/spa2018/sessions/session809.html">Typing is not the hard part - Developing a culture of pair programming</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/thomaslee.html">Thomas Lee</a>, GDS
+  <a href="/spa2018/people/thomaslee.html">Thomas Lee</a>, GDS
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/emmabeynon.html">Emma Beynon</a>, Government Digital Service
+  <a href="/spa2018/people/emmabeynon.html">Emma Beynon</a>, Government Digital Service
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/bevanloon.html">Bevan Loon</a>, Government Digital Service
+  <a href="/spa2018/people/bevanloon.html">Bevan Loon</a>, Government Digital Service
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>16:15  -  17:30</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session822.html">Why Cultivating Observational Skills are so important?</a></h4>
+      <h4><a href="/spa2018/sessions/session822.html">Why Cultivating Observational Skills are so important?</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/mohinderkhosla.html">Mohinder Khosla</a>, Retired
+  <a href="/spa2018/people/mohinderkhosla.html">Mohinder Khosla</a>, Retired
 </li>
 </ul>
     </div>
 </li><li class="all-tracks">
-  <h3><span class='time'>17:30  -  18:15</span></h3> <a href=https://spaconference.org/spa2018/bof.html>Birds of a feather</a>
+  <h3><span class='time'>17:30  -  18:15</span></h3> <a href=/spa2018/bof.html>Birds of a feather</a>
 </li><li class="all-tracks">
-  <h3><span class='time'>18:15  -  21:00</span></h3> <a href=https://spaconference.org/spa2018/social.html>Dinner & diversions</a>
+  <h3><span class='time'>18:15  -  21:00</span></h3> <a href=/spa2018/social.html>Dinner & diversions</a>
 </li></ol><h2>Tuesday 3rd July</h2><ol><li class="all-tracks">
   <h3><span class='time'>08:30  -  09:15</span></h3> Registration
 </li><li class="track-1">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session817.html">Failure Patterns in Java</a></h4>
+      <h4><a href="/spa2018/sessions/session817.html">Failure Patterns in Java</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/tomjohnson.html">Tom Johnson</a>, Unruly
+  <a href="/spa2018/people/tomjohnson.html">Tom Johnson</a>, Unruly
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session782.html">&lsquo;What would YOU Call This Workshop?&rsquo; And Other Powerful Questions</a></h4>
+      <h4><a href="/spa2018/sessions/session782.html">&lsquo;What would YOU Call This Workshop?&rsquo; And Other Powerful Questions</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/timbourguignon.html">Tim Bourguignon</a>, MATHEMA Software GmbH
+  <a href="/spa2018/people/timbourguignon.html">Tim Bourguignon</a>, MATHEMA Software GmbH
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/amitaischleier.html">Amitai Schleier</a>, Latent Agility
+  <a href="/spa2018/people/amitaischleier.html">Amitai Schleier</a>, Latent Agility
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session782.html">&lsquo;What would YOU Call This Workshop?&rsquo; And Other Powerful Questions</a></h4>
+      <h4><a href="/spa2018/sessions/session782.html">&lsquo;What would YOU Call This Workshop?&rsquo; And Other Powerful Questions</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/timbourguignon.html">Tim Bourguignon</a>, MATHEMA Software GmbH
+  <a href="/spa2018/people/timbourguignon.html">Tim Bourguignon</a>, MATHEMA Software GmbH
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/amitaischleier.html">Amitai Schleier</a>, Latent Agility
+  <a href="/spa2018/people/amitaischleier.html">Amitai Schleier</a>, Latent Agility
 </li>
 </ul>
     </div>
@@ -195,32 +195,32 @@
 </li><li class="track-1">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session827.html">Functional Programming Beyond Immutability</a></h4>
+      <h4><a href="/spa2018/sessions/session827.html">Functional Programming Beyond Immutability</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/duncanmcgregor.html">Duncan McGregor</a>, Independent
+  <a href="/spa2018/people/duncanmcgregor.html">Duncan McGregor</a>, Independent
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/nathanielpryce.html">Nat Pryce</a>, Technemetis Ltd.
+  <a href="/spa2018/people/nathanielpryce.html">Nat Pryce</a>, Technemetis Ltd.
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session796.html">Muddling Through The Middle Bits: what comes after Junior and before Senior</a></h4>
+      <h4><a href="/spa2018/sessions/session796.html">Muddling Through The Middle Bits: what comes after Junior and before Senior</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/annecahalan.html">Anne Cahalan</a>, Detroit Labs
+  <a href="/spa2018/people/annecahalan.html">Anne Cahalan</a>, Detroit Labs
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session815.html">Better Whiteboard Sketches</a></h4>
+      <h4><a href="/spa2018/sessions/session815.html">Better Whiteboard Sketches</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/matthewskelton.html">Matthew Skelton</a>, Conflux
+  <a href="/spa2018/people/matthewskelton.html">Matthew Skelton</a>, Conflux
 </li>
 </ul>
     </div>
@@ -229,7 +229,7 @@
 </li><li class="all-tracks">
   <h3><span class='time'>13:00  -  14:00</span></h3>
   <div>
-    <h4><a href="https://spaconference.org/spa2018/announcements/keynotes/2018/02/28/launching-spa-2018.html">Keynote</a></h4>
+    <h4><a href="/spa2018/announcements/keynotes/2018/02/28/launching-spa-2018.html">Keynote</a></h4>
     <ul><li>Jon Skeet</li></ul>
   </div>
 </li><li class="all-tracks break">
@@ -237,34 +237,34 @@
 </li><li class="track-1">
   <h3><span class='time'>14:15  -  15:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session821.html">The Virtuous Technologist</a></h4>
+      <h4><a href="/spa2018/sessions/session821.html">The Virtuous Technologist</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/johnnolan.html">John Nolan</a>, Masabi
+  <a href="/spa2018/people/johnnolan.html">John Nolan</a>, Masabi
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>14:15  -  15:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session753.html">EventStorming: a Hands-On</a></h4>
+      <h4><a href="/spa2018/sessions/session753.html">EventStorming: a Hands-On</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/yveslorphelin.html">Yves Lorphelin</a>, Spikes
+  <a href="/spa2018/people/yveslorphelin.html">Yves Lorphelin</a>, Spikes
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>14:15  -  15:30</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session792.html">Internet of things with physical programming</a></h4>
+      <h4><a href="/spa2018/sessions/session792.html">Internet of things with physical programming</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/venusbailey.html">Venus Bailey</a>, Government Digital Service
+  <a href="/spa2018/people/venusbailey.html">Venus Bailey</a>, Government Digital Service
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/maisiefernandes.html">Maisie Fernandes</a>, Government Digital Service
+  <a href="/spa2018/people/maisiefernandes.html">Maisie Fernandes</a>, Government Digital Service
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/irenelau.html">Irene Lau</a>, Government Digital Service
+  <a href="/spa2018/people/irenelau.html">Irene Lau</a>, Government Digital Service
 </li>
 </ul>
     </div>
@@ -273,70 +273,70 @@
 </li><li class="track-1">
   <h3><span class='time'>15:45  -  17:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session821.html">The Virtuous Technologist</a></h4>
+      <h4><a href="/spa2018/sessions/session821.html">The Virtuous Technologist</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/johnnolan.html">John Nolan</a>, Masabi
+  <a href="/spa2018/people/johnnolan.html">John Nolan</a>, Masabi
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>15:45  -  17:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session753.html">EventStorming: a Hands-On</a></h4>
+      <h4><a href="/spa2018/sessions/session753.html">EventStorming: a Hands-On</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/yveslorphelin.html">Yves Lorphelin</a>, Spikes
+  <a href="/spa2018/people/yveslorphelin.html">Yves Lorphelin</a>, Spikes
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>15:45  -  17:00</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session792.html">Internet of things with physical programming</a></h4>
+      <h4><a href="/spa2018/sessions/session792.html">Internet of things with physical programming</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/venusbailey.html">Venus Bailey</a>, Government Digital Service
+  <a href="/spa2018/people/venusbailey.html">Venus Bailey</a>, Government Digital Service
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/maisiefernandes.html">Maisie Fernandes</a>, Government Digital Service
+  <a href="/spa2018/people/maisiefernandes.html">Maisie Fernandes</a>, Government Digital Service
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/irenelau.html">Irene Lau</a>, Government Digital Service
+  <a href="/spa2018/people/irenelau.html">Irene Lau</a>, Government Digital Service
 </li>
 </ul>
     </div>
 </li><li class="all-tracks">
   <h3><span class='time'>17:15  -  18:00</span></h3> Lightning talks
 </li><li class="all-tracks">
-  <h3><span class='time'>18:00  -  21:00</span></h3> <a href=https://spaconference.org/spa2018/social.html>Dinner & diversions</a>
+  <h3><span class='time'>18:00  -  21:00</span></h3> <a href=/spa2018/social.html>Dinner & diversions</a>
 </li></ol><h2>Wednesday 4th July</h2><ol><li class="all-tracks">
   <h3><span class='time'>08:30  -  09:15</span></h3> Registration
 </li><li class="track-1">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session825.html">Well what would you do next...?</a></h4>
+      <h4><a href="/spa2018/sessions/session825.html">Well what would you do next...?</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/johnarmstrongprior.html">John Armstrong-Prior</a>, Capital One UK
+  <a href="/spa2018/people/johnarmstrongprior.html">John Armstrong-Prior</a>, Capital One UK
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session754.html">Dealing with Disempowerment</a></h4>
+      <h4><a href="/spa2018/sessions/session754.html">Dealing with Disempowerment</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/markdalgarno.html">Mark Dalgarno</a>, Software Acumen
+  <a href="/spa2018/people/markdalgarno.html">Mark Dalgarno</a>, Software Acumen
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session794.html">Building Universal Apps with React</a></h4>
+      <h4><a href="/spa2018/sessions/session794.html">Building Universal Apps with React</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/elysekolkergordon.html">Elyse Kolker Gordon</a>, Strava
+  <a href="/spa2018/people/elysekolkergordon.html">Elyse Kolker Gordon</a>, Strava
 </li>
 </ul>
     </div>
@@ -345,36 +345,36 @@
 </li><li class="track-1">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session802.html">Negotiating For Your Life</a></h4>
+      <h4><a href="/spa2018/sessions/session802.html">Negotiating For Your Life</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/portiatung.html">Portia Tung</a>, The School of Play
+  <a href="/spa2018/people/portiatung.html">Portia Tung</a>, The School of Play
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/tomroden.html">Tom Roden</a>, Neuri Consulting
+  <a href="/spa2018/people/tomroden.html">Tom Roden</a>, Neuri Consulting
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/marcomilone.html">Marco Milone</a>
+  <a href="/spa2018/people/marcomilone.html">Marco Milone</a>
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session816.html">Learn to run agile game sessions</a></h4>
+      <h4><a href="/spa2018/sessions/session816.html">Learn to run agile game sessions</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/katyarmstrong.html">Katy Armstrong</a>, MHCLG
+  <a href="/spa2018/people/katyarmstrong.html">Katy Armstrong</a>, MHCLG
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/xanderharrison.html">Xander Harrison</a>, Government Digital Service
+  <a href="/spa2018/people/xanderharrison.html">Xander Harrison</a>, Government Digital Service
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session794.html">Building Universal Apps with React</a></h4>
+      <h4><a href="/spa2018/sessions/session794.html">Building Universal Apps with React</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/elysekolkergordon.html">Elyse Kolker Gordon</a>, Strava
+  <a href="/spa2018/people/elysekolkergordon.html">Elyse Kolker Gordon</a>, Strava
 </li>
 </ul>
     </div>
@@ -383,32 +383,32 @@
 </li><li class="track-1">
   <h3><span class='time'>13:00  -  14:15</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session819.html">Strangle Your Legacy Code</a></h4>
+      <h4><a href="/spa2018/sessions/session819.html">Strangle Your Legacy Code</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/amitaischleier.html">Amitai Schleier</a>, Latent Agility
+  <a href="/spa2018/people/amitaischleier.html">Amitai Schleier</a>, Latent Agility
 </li><li>
-  <a href="https://spaconference.org/spa2018/people/timbourguignon.html">Tim Bourguignon</a>, MATHEMA Software GmbH
+  <a href="/spa2018/people/timbourguignon.html">Tim Bourguignon</a>, MATHEMA Software GmbH
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>13:00  -  14:15</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session793.html">Build a &quot;Development for Non-Developers&quot; Course</a></h4>
+      <h4><a href="/spa2018/sessions/session793.html">Build a &quot;Development for Non-Developers&quot; Course</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/ivansanchez.html">Ivan Sanchez</a>, Gourame Limited
+  <a href="/spa2018/people/ivansanchez.html">Ivan Sanchez</a>, Gourame Limited
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>13:00  -  14:15</span><span class="room">Wilkes 3 & 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2018/sessions/session826.html">Teamwork: What Must Go Right/What Can Go Wrong</a></h4>
+      <h4><a href="/spa2018/sessions/session826.html">Teamwork: What Must Go Right/What Can Go Wrong</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2018/people/giovanniasproni.html">Giovanni Asproni</a>, Zuhlke Engineering
+  <a href="/spa2018/people/giovanniasproni.html">Giovanni Asproni</a>, Zuhlke Engineering
 </li>
 </ul>
     </div>

--- a/spa2018/sessions/session747.html
+++ b/spa2018/sessions/session747.html
@@ -56,7 +56,7 @@ Side note (I see no field for notes?): The hardware I would like to provide is $
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/georgemandis.html">George Mandis</a><i><br>SnapTortoise</i></li>
+  <li><a href="/spa2018/people/georgemandis.html">George Mandis</a><i><br>SnapTortoise</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session751.html
+++ b/spa2018/sessions/session751.html
@@ -56,7 +56,7 @@ case study materials</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/crystalyan.html">Crystal Yan</a><i></i></li>
+  <li><a href="/spa2018/people/crystalyan.html">Crystal Yan</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session753.html
+++ b/spa2018/sessions/session753.html
@@ -104,7 +104,7 @@ Pointers & links to available resources.<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/yveslorphelin.html">Yves Lorphelin</a><i><br>Spikes</i></li>
+  <li><a href="/spa2018/people/yveslorphelin.html">Yves Lorphelin</a><i><br>Spikes</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session754.html
+++ b/spa2018/sessions/session754.html
@@ -84,7 +84,7 @@ I will close the session with a few observations on the main findings of the ses
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/markdalgarno.html">Mark Dalgarno</a><i><br>Software Acumen</i></li>
+  <li><a href="/spa2018/people/markdalgarno.html">Mark Dalgarno</a><i><br>Software Acumen</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session768.html
+++ b/spa2018/sessions/session768.html
@@ -70,7 +70,7 @@ Exercise 4: 10 Circles<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/rizwanjavaid.html">Rizwan Javaid</a><i><br>Slalom Consulting</i></li>
+  <li><a href="/spa2018/people/rizwanjavaid.html">Rizwan Javaid</a><i><br>Slalom Consulting</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session780.html
+++ b/spa2018/sessions/session780.html
@@ -51,7 +51,7 @@ O’Reilly Software Architecture Conference, New York, 2017 <br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/evelynvankelle.html">Evelyn van Kelle</a><i></i></li>
+  <li><a href="/spa2018/people/evelynvankelle.html">Evelyn van Kelle</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session781.html
+++ b/spa2018/sessions/session781.html
@@ -44,7 +44,7 @@ The rest of the time: everyone scanning with Zap and discussing the report.</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/tanyajanca.html">Tanya Janca</a><i><br>Microsoft</i></li>
+  <li><a href="/spa2018/people/tanyajanca.html">Tanya Janca</a><i><br>Microsoft</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session782.html
+++ b/spa2018/sessions/session782.html
@@ -51,8 +51,8 @@ Blog post with summary and slides.</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/timbourguignon.html">Tim Bourguignon</a><i><br>MATHEMA Software GmbH</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/amitaischleier.html">Amitai Schleier</a><i><br>Latent Agility</i></li>
+  <li><a href="/spa2018/people/timbourguignon.html">Tim Bourguignon</a><i><br>MATHEMA Software GmbH</i></li>
+  <li><a href="/spa2018/people/amitaischleier.html">Amitai Schleier</a><i><br>Latent Agility</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session791.html
+++ b/spa2018/sessions/session791.html
@@ -53,8 +53,8 @@ More specifically to explore:<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/katiec.html">Katie Coleman</a><i><br>FutureLearn</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/traceywalker.html">Tracey  Walker</a><i><br>FutureLearn</i></li>
+  <li><a href="/spa2018/people/katiec.html">Katie Coleman</a><i><br>FutureLearn</i></li>
+  <li><a href="/spa2018/people/traceywalker.html">Tracey  Walker</a><i><br>FutureLearn</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session792.html
+++ b/spa2018/sessions/session792.html
@@ -71,9 +71,9 @@ Maybe a GDS blog post<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/venusbailey.html">Venus Bailey</a><i><br>Government Digital Service</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/maisiefernandes.html">Maisie Fernandes</a><i><br>Government Digital Service</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/irenelau.html">Irene Lau</a><i><br>Government Digital Service</i></li>
+  <li><a href="/spa2018/people/venusbailey.html">Venus Bailey</a><i><br>Government Digital Service</i></li>
+  <li><a href="/spa2018/people/maisiefernandes.html">Maisie Fernandes</a><i><br>Government Digital Service</i></li>
+  <li><a href="/spa2018/people/irenelau.html">Irene Lau</a><i><br>Government Digital Service</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session793.html
+++ b/spa2018/sessions/session793.html
@@ -57,7 +57,7 @@ The process of designing this kind of training was also fascinating, so this wor
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/ivansanchez.html">Ivan Sanchez</a><i><br>Gourame Limited</i></li>
+  <li><a href="/spa2018/people/ivansanchez.html">Ivan Sanchez</a><i><br>Gourame Limited</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session794.html
+++ b/spa2018/sessions/session794.html
@@ -62,7 +62,7 @@ In the feedback, someone noted that perhaps this session could use more time. If
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/elysekolkergordon.html">Elyse Kolker Gordon</a><i><br>Strava</i></li>
+  <li><a href="/spa2018/people/elysekolkergordon.html">Elyse Kolker Gordon</a><i><br>Strava</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session796.html
+++ b/spa2018/sessions/session796.html
@@ -24,7 +24,7 @@ include("../programme_includes/session_header.html");
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/annecahalan.html">Anne Cahalan</a><i><br>Detroit Labs</i></li>
+  <li><a href="/spa2018/people/annecahalan.html">Anne Cahalan</a><i><br>Detroit Labs</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session802.html
+++ b/spa2018/sessions/session802.html
@@ -53,9 +53,9 @@ Working in small groups<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/portiatung.html">Portia Tung</a><i><br>The School of Play</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/tomroden.html">Tom Roden</a><i><br>Neuri Consulting</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/marcomilone.html">Marco Milone</a><i></i></li>
+  <li><a href="/spa2018/people/portiatung.html">Portia Tung</a><i><br>The School of Play</i></li>
+  <li><a href="/spa2018/people/tomroden.html">Tom Roden</a><i><br>Neuri Consulting</i></li>
+  <li><a href="/spa2018/people/marcomilone.html">Marco Milone</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session807.html
+++ b/spa2018/sessions/session807.html
@@ -41,7 +41,7 @@ Exercises and references: <a href="https://regex-performance.github.io/exercises
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/maciejrzasa.html">Maciej Rzasa</a><i><br>TextMaster</i></li>
+  <li><a href="/spa2018/people/maciejrzasa.html">Maciej Rzasa</a><i><br>TextMaster</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session809.html
+++ b/spa2018/sessions/session809.html
@@ -46,9 +46,9 @@ Develop communication skills<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/thomaslee.html">Thomas Lee</a><i><br>GDS</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/emmabeynon.html">Emma Beynon</a><i><br>Government Digital Service</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/bevanloon.html">Bevan Loon</a><i><br>Government Digital Service</i></li>
+  <li><a href="/spa2018/people/thomaslee.html">Thomas Lee</a><i><br>GDS</i></li>
+  <li><a href="/spa2018/people/emmabeynon.html">Emma Beynon</a><i><br>Government Digital Service</i></li>
+  <li><a href="/spa2018/people/bevanloon.html">Bevan Loon</a><i><br>Government Digital Service</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session813.html
+++ b/spa2018/sessions/session813.html
@@ -65,9 +65,9 @@ In a moderated discussion, attendees will apply the approach used in the first t
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/tamaralopez.html">Tamara Lopez</a><i><br>The Open University</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/helensharp.html">Helen Sharp</a><i><br>The Open University</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/theintun.html">Thein Tun</a><i><br>The Open University</i></li>
+  <li><a href="/spa2018/people/tamaralopez.html">Tamara Lopez</a><i><br>The Open University</i></li>
+  <li><a href="/spa2018/people/helensharp.html">Helen Sharp</a><i><br>The Open University</i></li>
+  <li><a href="/spa2018/people/theintun.html">Thein Tun</a><i><br>The Open University</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session815.html
+++ b/spa2018/sessions/session815.html
@@ -56,7 +56,7 @@ See <a href="http://betterwhiteboardsketches.com/">http://betterwhiteboardsketch
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/matthewskelton.html">Matthew Skelton</a><i><br>Conflux</i></li>
+  <li><a href="/spa2018/people/matthewskelton.html">Matthew Skelton</a><i><br>Conflux</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session816.html
+++ b/spa2018/sessions/session816.html
@@ -57,8 +57,8 @@ By the end of the session, delegates should feel confident to lead these games <
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/katyarmstrong.html">Katy Armstrong</a><i><br>MHCLG</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/xanderharrison.html">Xander Harrison</a><i><br>Government Digital Service</i></li>
+  <li><a href="/spa2018/people/katyarmstrong.html">Katy Armstrong</a><i><br>MHCLG</i></li>
+  <li><a href="/spa2018/people/xanderharrison.html">Xander Harrison</a><i><br>Government Digital Service</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session817.html
+++ b/spa2018/sessions/session817.html
@@ -62,7 +62,7 @@ Repeated a number of times, building up a more sophisticated and layered underst
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/tomjohnson.html">Tom Johnson</a><i><br>Unruly</i></li>
+  <li><a href="/spa2018/people/tomjohnson.html">Tom Johnson</a><i><br>Unruly</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session819.html
+++ b/spa2018/sessions/session819.html
@@ -43,8 +43,8 @@ As a mob, we'll take a quick look at a Strangler, then test-drive new features i
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/amitaischleier.html">Amitai Schleier</a><i><br>Latent Agility</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/timbourguignon.html">Tim Bourguignon</a><i><br>MATHEMA Software GmbH</i></li>
+  <li><a href="/spa2018/people/amitaischleier.html">Amitai Schleier</a><i><br>Latent Agility</i></li>
+  <li><a href="/spa2018/people/timbourguignon.html">Tim Bourguignon</a><i><br>MATHEMA Software GmbH</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session821.html
+++ b/spa2018/sessions/session821.html
@@ -57,7 +57,7 @@ Posters by groups on potential programmes for Virtue-based Ethics<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/johnnolan.html">John Nolan</a><i><br>Masabi</i></li>
+  <li><a href="/spa2018/people/johnnolan.html">John Nolan</a><i><br>Masabi</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session822.html
+++ b/spa2018/sessions/session822.html
@@ -50,7 +50,7 @@ SPA 2015</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/mohinderkhosla.html">Mohinder Khosla</a><i><br>Retired</i></li>
+  <li><a href="/spa2018/people/mohinderkhosla.html">Mohinder Khosla</a><i><br>Retired</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session824.html
+++ b/spa2018/sessions/session824.html
@@ -55,7 +55,7 @@ Research methods content </p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/juliannebowman.html">Julianne Bowman</a><i></i></li>
+  <li><a href="/spa2018/people/juliannebowman.html">Julianne Bowman</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session825.html
+++ b/spa2018/sessions/session825.html
@@ -53,7 +53,7 @@ We'll also look at possible strategies for: <br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/johnarmstrongprior.html">John Armstrong-Prior</a><i><br>Capital One UK</i></li>
+  <li><a href="/spa2018/people/johnarmstrongprior.html">John Armstrong-Prior</a><i><br>Capital One UK</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session826.html
+++ b/spa2018/sessions/session826.html
@@ -51,7 +51,7 @@ The title is from a book from Carl Larson and Frank M. J. Lafasto, where the aut
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/giovanniasproni.html">Giovanni Asproni</a><i><br>Zuhlke Engineering</i></li>
+  <li><a href="/spa2018/people/giovanniasproni.html">Giovanni Asproni</a><i><br>Zuhlke Engineering</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2018/sessions/session827.html
+++ b/spa2018/sessions/session827.html
@@ -26,8 +26,8 @@ Kotlin has proved a gateway drug to to a purer functional style. In this session
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2018/people/duncanmcgregor.html">Duncan McGregor</a><i><br>Independent</i></li>
-  <li><a href="https://spaconference.org/spa2018/people/nathanielpryce.html">Nat Pryce</a><i><br>Technemetis Ltd.</i></li>
+  <li><a href="/spa2018/people/duncanmcgregor.html">Duncan McGregor</a><i><br>Independent</i></li>
+  <li><a href="/spa2018/people/nathanielpryce.html">Nat Pryce</a><i><br>Technemetis Ltd.</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/programme.html
+++ b/spa2019/programme.html
@@ -5,30 +5,30 @@
 </li><li class="track-1">
   <h3><span class='time'>09:45  -  11:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session849.html">Made-Making-Maker: (co)operational and artifactual viewpoints of technical practices</a></h4>
+      <h4><a href="/spa2019/sessions/session849.html">Made-Making-Maker: (co)operational and artifactual viewpoints of technical practices</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/nathanielpryce.html">Nat Pryce</a>, Technemetis Ltd.
+  <a href="/spa2019/people/nathanielpryce.html">Nat Pryce</a>, Technemetis Ltd.
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>09:45  -  11:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session841.html">Re-claiming the future of agile software development, from the past</a></h4>
+      <h4><a href="/spa2019/sessions/session841.html">Re-claiming the future of agile software development, from the past</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/lucaminudel.html">Luca Minudel</a>, SmHarter Ltd
+  <a href="/spa2019/people/lucaminudel.html">Luca Minudel</a>, SmHarter Ltd
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>09:45  -  11:00</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session832.html">Defining Aspects of Software Quality</a></h4>
+      <h4><a href="/spa2019/sessions/session832.html">Defining Aspects of Software Quality</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/davearonson.html">Dave Aronson</a>, Codosaurus, LLC
+  <a href="/spa2019/people/davearonson.html">Dave Aronson</a>, Codosaurus, LLC
 </li>
 </ul>
     </div>
@@ -40,30 +40,30 @@
 </li><li class="track-1">
   <h3><span class='time'>11:15  -  12:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session838.html">Paving the Cow Paths: Finding and Leveraging User-Generated Documentation</a></h4>
+      <h4><a href="/spa2019/sessions/session838.html">Paving the Cow Paths: Finding and Leveraging User-Generated Documentation</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/eringrace.html">Erin Grace</a>
+  <a href="/spa2019/people/eringrace.html">Erin Grace</a>
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>11:15  -  12:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session833.html">Agile Technical practices coaching</a></h4>
+      <h4><a href="/spa2019/sessions/session833.html">Agile Technical practices coaching</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/pedrosantos.html">Pedro Santos</a>
+  <a href="/spa2019/people/pedrosantos.html">Pedro Santos</a>
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>11:15  -  12:30</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session832.html">Defining Aspects of Software Quality</a></h4>
+      <h4><a href="/spa2019/sessions/session832.html">Defining Aspects of Software Quality</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/davearonson.html">Dave Aronson</a>, Codosaurus, LLC
+  <a href="/spa2019/people/davearonson.html">Dave Aronson</a>, Codosaurus, LLC
 </li>
 </ul>
     </div>
@@ -83,42 +83,42 @@
 </li><li class="track-1">
   <h3><span class='time'>14:45  -  16:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session847.html">Crafting Secure Software</a></h4>
+      <h4><a href="/spa2019/sessions/session847.html">Crafting Secure Software</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/yvanphelizot.html">Yvan PHELIZOT</a>, Arolla
+  <a href="/spa2019/people/yvanphelizot.html">Yvan PHELIZOT</a>, Arolla
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>14:45  -  16:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session861.html">From inspiration to change: take SPA to work</a></h4>
+      <h4><a href="/spa2019/sessions/session861.html">From inspiration to change: take SPA to work</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/wimheemskerk.html">Wim Heemskerk</a>, Beyond Agile
+  <a href="/spa2019/people/wimheemskerk.html">Wim Heemskerk</a>, Beyond Agile
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/eddybruin.html">Eddy Bruin</a>, Loop Forward
+  <a href="/spa2019/people/eddybruin.html">Eddy Bruin</a>, Loop Forward
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>14:45  -  16:00</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session854.html">Iterating on domain models</a></h4>
+      <h4><a href="/spa2019/sessions/session854.html">Iterating on domain models</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/marijnhuizendveld.html">Marijn Huizendveld</a>, Marijn Huizendveld B.V. 
+  <a href="/spa2019/people/marijnhuizendveld.html">Marijn Huizendveld</a>, Marijn Huizendveld B.V. 
 </li>
 </ul>
     </div>
 </li><li class="track-4">
   <h3><span class='time'>14:45  -  16:00</span><span class="room">Wilkes 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session864.html">Google Assistant Development 101: Foundation Hands-On Workshop</a></h4>
+      <h4><a href="/spa2019/sessions/session864.html">Google Assistant Development 101: Foundation Hands-On Workshop</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/aygulzagidullina.html">Aygul Zagidullina</a>
+  <a href="/spa2019/people/aygulzagidullina.html">Aygul Zagidullina</a>
 </li>
 </ul>
     </div>
@@ -127,72 +127,72 @@
 </li><li class="track-1">
   <h3><span class='time'>16:15  -  17:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session847.html">Crafting Secure Software</a></h4>
+      <h4><a href="/spa2019/sessions/session847.html">Crafting Secure Software</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/yvanphelizot.html">Yvan PHELIZOT</a>, Arolla
+  <a href="/spa2019/people/yvanphelizot.html">Yvan PHELIZOT</a>, Arolla
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>16:15  -  17:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session861.html">From inspiration to change: take SPA to work</a></h4>
+      <h4><a href="/spa2019/sessions/session861.html">From inspiration to change: take SPA to work</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/wimheemskerk.html">Wim Heemskerk</a>, Beyond Agile
+  <a href="/spa2019/people/wimheemskerk.html">Wim Heemskerk</a>, Beyond Agile
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/eddybruin.html">Eddy Bruin</a>, Loop Forward
+  <a href="/spa2019/people/eddybruin.html">Eddy Bruin</a>, Loop Forward
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>16:15  -  17:30</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session854.html">Iterating on domain models</a></h4>
+      <h4><a href="/spa2019/sessions/session854.html">Iterating on domain models</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/marijnhuizendveld.html">Marijn Huizendveld</a>, Marijn Huizendveld B.V. 
+  <a href="/spa2019/people/marijnhuizendveld.html">Marijn Huizendveld</a>, Marijn Huizendveld B.V. 
 </li>
 </ul>
     </div>
 </li><li class="track-4">
   <h3><span class='time'>16:15  -  17:30</span><span class="room">Wilkes 4</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session864.html">Google Assistant Development 101: Foundation Hands-On Workshop</a></h4>
+      <h4><a href="/spa2019/sessions/session864.html">Google Assistant Development 101: Foundation Hands-On Workshop</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/aygulzagidullina.html">Aygul Zagidullina</a>
+  <a href="/spa2019/people/aygulzagidullina.html">Aygul Zagidullina</a>
 </li>
 </ul>
     </div>
 </li><li class="all-tracks">
-  <h3><span class='time'>17:30  -  18:15</span></h3> <a href=https://spaconference.org/spa2019/bof.html>Birds of a feather</a>
+  <h3><span class='time'>17:30  -  18:15</span></h3> <a href=/spa2019/bof.html>Birds of a feather</a>
 </li><li class="all-tracks">
-  <h3><span class='time'>18:15  -  21:00</span></h3> <a href=https://spaconference.org/spa2019/social.html>Dinner & diversions</a>
+  <h3><span class='time'>18:15  -  21:00</span></h3> <a href=/spa2019/social.html>Dinner & diversions</a>
 </li></ol><h2>Tuesday 25th June</h2><ol class='four-tracks'><li class="all-tracks">
   <h3><span class='time'>08:30  -  09:15</span></h3> Registration
 </li><li class="track-1">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session858.html">Tallying and Taming Technical Debt</a></h4>
+      <h4><a href="/spa2019/sessions/session858.html">Tallying and Taming Technical Debt</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/eoinwoods.html">Eoin Woods</a>, Endava
+  <a href="/spa2019/people/eoinwoods.html">Eoin Woods</a>, Endava
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/nickrozanski.html">Nick Rozanski</a>, ICBC Standard Bank
+  <a href="/spa2019/people/nickrozanski.html">Nick Rozanski</a>, ICBC Standard Bank
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/andylongshaw.html">Andy Longshaw</a>, Coop Digital
+  <a href="/spa2019/people/andylongshaw.html">Andy Longshaw</a>, Coop Digital
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session856.html">Surviving surveillance capitalism</a></h4>
+      <h4><a href="/spa2019/sessions/session856.html">Surviving surveillance capitalism</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/johanpeeters.html">Johan Peeters</a>, Johan Peeters bvba
+  <a href="/spa2019/people/johanpeeters.html">Johan Peeters</a>, Johan Peeters bvba
 </li>
 </ul>
     </div>
@@ -207,36 +207,36 @@
 </li><li class="track-1">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session858.html">Tallying and Taming Technical Debt</a></h4>
+      <h4><a href="/spa2019/sessions/session858.html">Tallying and Taming Technical Debt</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/eoinwoods.html">Eoin Woods</a>, Endava
+  <a href="/spa2019/people/eoinwoods.html">Eoin Woods</a>, Endava
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/nickrozanski.html">Nick Rozanski</a>, ICBC Standard Bank
+  <a href="/spa2019/people/nickrozanski.html">Nick Rozanski</a>, ICBC Standard Bank
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/andylongshaw.html">Andy Longshaw</a>, Coop Digital
+  <a href="/spa2019/people/andylongshaw.html">Andy Longshaw</a>, Coop Digital
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session856.html">Surviving surveillance capitalism</a></h4>
+      <h4><a href="/spa2019/sessions/session856.html">Surviving surveillance capitalism</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/johanpeeters.html">Johan Peeters</a>, Johan Peeters bvba
+  <a href="/spa2019/people/johanpeeters.html">Johan Peeters</a>, Johan Peeters bvba
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session859.html">Computing for Humanity (Values in Computing)</a></h4>
+      <h4><a href="/spa2019/sessions/session859.html">Computing for Humanity (Values in Computing)</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/lucyhunt.html">Lucy Hunt</a>, Lancaster University
+  <a href="/spa2019/people/lucyhunt.html">Lucy Hunt</a>, Lancaster University
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/peggygregory.html">Peggy Gregory</a>
+  <a href="/spa2019/people/peggygregory.html">Peggy Gregory</a>
 </li>
 </ul>
     </div>
@@ -256,30 +256,30 @@
 </li><li class="track-1">
   <h3><span class='time'>14:15  -  15:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session835.html">The Road to Consumer Driven Contracts testing for SOA and Microservices Architecture</a></h4>
+      <h4><a href="/spa2019/sessions/session835.html">The Road to Consumer Driven Contracts testing for SOA and Microservices Architecture</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/lirantal.html">Liran Tal</a>
+  <a href="/spa2019/people/lirantal.html">Liran Tal</a>
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>14:15  -  15:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session844.html">A quest at mapping Domain-Driven Design Heuristics</a></h4>
+      <h4><a href="/spa2019/sessions/session844.html">A quest at mapping Domain-Driven Design Heuristics</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a>, Xebia
+  <a href="/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a>, Xebia
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>14:15  -  15:30</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session855.html">User Story Mapping for Domain Discovery</a></h4>
+      <h4><a href="/spa2019/sessions/session855.html">User Story Mapping for Domain Discovery</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/trondhjorteland.html">Trond Hjorteland</a>, Scienta
+  <a href="/spa2019/people/trondhjorteland.html">Trond Hjorteland</a>, Scienta
 </li>
 </ul>
     </div>
@@ -291,30 +291,30 @@
 </li><li class="track-1">
   <h3><span class='time'>15:45  -  17:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session835.html">The Road to Consumer Driven Contracts testing for SOA and Microservices Architecture</a></h4>
+      <h4><a href="/spa2019/sessions/session835.html">The Road to Consumer Driven Contracts testing for SOA and Microservices Architecture</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/lirantal.html">Liran Tal</a>
+  <a href="/spa2019/people/lirantal.html">Liran Tal</a>
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>15:45  -  17:00</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session844.html">A quest at mapping Domain-Driven Design Heuristics</a></h4>
+      <h4><a href="/spa2019/sessions/session844.html">A quest at mapping Domain-Driven Design Heuristics</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a>, Xebia
+  <a href="/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a>, Xebia
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>15:45  -  17:00</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session855.html">User Story Mapping for Domain Discovery</a></h4>
+      <h4><a href="/spa2019/sessions/session855.html">User Story Mapping for Domain Discovery</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/trondhjorteland.html">Trond Hjorteland</a>, Scienta
+  <a href="/spa2019/people/trondhjorteland.html">Trond Hjorteland</a>, Scienta
 </li>
 </ul>
     </div>
@@ -324,38 +324,38 @@
 </li><li class="all-tracks">
   <h3><span class='time'>17:15  -  18:00</span></h3> Lightning talks
 </li><li class="all-tracks">
-  <h3><span class='time'>18:00  -  21:00</span></h3> <a href=https://spaconference.org/spa2019/social.html>Dinner & diversions</a>
+  <h3><span class='time'>18:00  -  21:00</span></h3> <a href=/spa2019/social.html>Dinner & diversions</a>
 </li></ol><h2>Wednesday 26th June</h2><ol class='four-tracks'><li class="all-tracks">
   <h3><span class='time'>08:30  -  09:15</span></h3> Registration
 </li><li class="track-1">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session877.html">Writing better UI end-to-end tests</a></h4>
+      <h4><a href="/spa2019/sessions/session877.html">Writing better UI end-to-end tests</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/raulrodriguez.html">Raul Rodriguez</a>, Zuhlke Engineering
+  <a href="/spa2019/people/raulrodriguez.html">Raul Rodriguez</a>, Zuhlke Engineering
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session834.html">Practice makes perfect</a></h4>
+      <h4><a href="/spa2019/sessions/session834.html">Practice makes perfect</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/orlandoperri.html">orlando perri</a>
+  <a href="/spa2019/people/orlandoperri.html">orlando perri</a>
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>09:15  -  10:30</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session845.html">Model Exploration Whirpool with EventStorming and Example Mapping</a></h4>
+      <h4><a href="/spa2019/sessions/session845.html">Model Exploration Whirpool with EventStorming and Example Mapping</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a>, Xebia
+  <a href="/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a>, Xebia
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/joorosa.html">Joo Rosa</a>
+  <a href="/spa2019/people/joorosa.html">Joo Rosa</a>
 </li>
 </ul>
     </div>
@@ -367,10 +367,10 @@
 </li><li class="track-1">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session877.html">Writing better UI end-to-end tests</a></h4>
+      <h4><a href="/spa2019/sessions/session877.html">Writing better UI end-to-end tests</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/raulrodriguez.html">Raul Rodriguez</a>, Zuhlke Engineering
+  <a href="/spa2019/people/raulrodriguez.html">Raul Rodriguez</a>, Zuhlke Engineering
 </li>
 </ul>
     </div>
@@ -380,12 +380,12 @@
 </li><li class="track-3">
   <h3><span class='time'>10:45  -  12:00</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session845.html">Model Exploration Whirpool with EventStorming and Example Mapping</a></h4>
+      <h4><a href="/spa2019/sessions/session845.html">Model Exploration Whirpool with EventStorming and Example Mapping</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a>, Xebia
+  <a href="/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a>, Xebia
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/joorosa.html">Joo Rosa</a>
+  <a href="/spa2019/people/joorosa.html">Joo Rosa</a>
 </li>
 </ul>
     </div>
@@ -397,36 +397,36 @@
 </li><li class="track-1">
   <h3><span class='time'>13:00  -  14:15</span><span class="room">Wilkes 1</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session860.html">Could you run the perfect SPA session?</a></h4>
+      <h4><a href="/spa2019/sessions/session860.html">Could you run the perfect SPA session?</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/paulshannon.html">Paul Shannon</a>, eLife Sciences Publications Ltd
+  <a href="/spa2019/people/paulshannon.html">Paul Shannon</a>, eLife Sciences Publications Ltd
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/hibrimarzook.html">Hibri Marzook</a>, Contino
+  <a href="/spa2019/people/hibrimarzook.html">Hibri Marzook</a>, Contino
 </li>
 </ul>
     </div>
 </li><li class="track-2">
   <h3><span class='time'>13:00  -  14:15</span><span class="room">Wilkes 2</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session860.html">Could you run the perfect SPA session?</a></h4>
+      <h4><a href="/spa2019/sessions/session860.html">Could you run the perfect SPA session?</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/paulshannon.html">Paul Shannon</a>, eLife Sciences Publications Ltd
+  <a href="/spa2019/people/paulshannon.html">Paul Shannon</a>, eLife Sciences Publications Ltd
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/hibrimarzook.html">Hibri Marzook</a>, Contino
+  <a href="/spa2019/people/hibrimarzook.html">Hibri Marzook</a>, Contino
 </li>
 </ul>
     </div>
 </li><li class="track-3">
   <h3><span class='time'>13:00  -  14:15</span><span class="room">Wilkes 3</span></h3>
     <div>
-      <h4><a href="https://spaconference.org/spa2019/sessions/session860.html">Could you run the perfect SPA session?</a></h4>
+      <h4><a href="/spa2019/sessions/session860.html">Could you run the perfect SPA session?</a></h4>
 <ul>
   <li>
-  <a href="https://spaconference.org/spa2019/people/paulshannon.html">Paul Shannon</a>, eLife Sciences Publications Ltd
+  <a href="/spa2019/people/paulshannon.html">Paul Shannon</a>, eLife Sciences Publications Ltd
 </li><li>
-  <a href="https://spaconference.org/spa2019/people/hibrimarzook.html">Hibri Marzook</a>, Contino
+  <a href="/spa2019/people/hibrimarzook.html">Hibri Marzook</a>, Contino
 </li>
 </ul>
     </div>

--- a/spa2019/sessions/session832.html
+++ b/spa2019/sessions/session832.html
@@ -72,7 +72,7 @@ Minutes 0-5: Intro to Dave, why he wasn't satisfied with existing definitions, a
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/davearonson.html">Dave Aronson</a><i><br>Codosaurus, LLC</i></li>
+  <li><a href="/spa2019/people/davearonson.html">Dave Aronson</a><i><br>Codosaurus, LLC</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session833.html
+++ b/spa2019/sessions/session833.html
@@ -35,7 +35,7 @@ References<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/pedrosantos.html">Pedro Santos</a><i></i></li>
+  <li><a href="/spa2019/people/pedrosantos.html">Pedro Santos</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session834.html
+++ b/spa2019/sessions/session834.html
@@ -46,7 +46,7 @@ The last 20 minutes can be used to review some of the implementations and Q&A.</
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/orlandoperri.html">orlando perri</a><i></i></li>
+  <li><a href="/spa2019/people/orlandoperri.html">orlando perri</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session835.html
+++ b/spa2019/sessions/session835.html
@@ -37,7 +37,7 @@ We’ll review the required DevOps related flows and dive to hands-on practical 
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/lirantal.html">Liran Tal</a><i></i></li>
+  <li><a href="/spa2019/people/lirantal.html">Liran Tal</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session838.html
+++ b/spa2019/sessions/session838.html
@@ -49,7 +49,7 @@ In this talk, I go into more depth about what "cow paths" even are, how they poi
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/eringrace.html">Erin Grace</a><i></i></li>
+  <li><a href="/spa2019/people/eringrace.html">Erin Grace</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session841.html
+++ b/spa2019/sessions/session841.html
@@ -77,7 +77,7 @@ While I'm comfortable in organising, facilitating, and summarising the outcomes 
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/lucaminudel.html">Luca Minudel</a><i><br>SmHarter Ltd</i></li>
+  <li><a href="/spa2019/people/lucaminudel.html">Luca Minudel</a><i><br>SmHarter Ltd</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session844.html
+++ b/spa2019/sessions/session844.html
@@ -55,7 +55,7 @@ After a short introduction about heuristics, we will start exploring, distilling
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a><i><br>Xebia</i></li>
+  <li><a href="/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a><i><br>Xebia</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session845.html
+++ b/spa2019/sessions/session845.html
@@ -40,8 +40,8 @@ Software architects</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a><i><br>Xebia</i></li>
-  <li><a href="https://spaconference.org/spa2019/people/joorosa.html">Joo Rosa</a><i></i></li>
+  <li><a href="/spa2019/people/kennybaas.html">Kenny Baas-Schwegler</a><i><br>Xebia</i></li>
+  <li><a href="/spa2019/people/joorosa.html">Joo Rosa</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session847.html
+++ b/spa2019/sessions/session847.html
@@ -60,7 +60,7 @@ Codebase (https://github.com/cotonne/bbl-crafting-secure-softwares)</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/yvanphelizot.html">Yvan PHELIZOT</a><i><br>Arolla</i></li>
+  <li><a href="/spa2019/people/yvanphelizot.html">Yvan PHELIZOT</a><i><br>Arolla</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session849.html
+++ b/spa2019/sessions/session849.html
@@ -43,7 +43,7 @@ I will blog any interesting conclusions.</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/nathanielpryce.html">Nat Pryce</a><i><br>Technemetis Ltd.</i></li>
+  <li><a href="/spa2019/people/nathanielpryce.html">Nat Pryce</a><i><br>Technemetis Ltd.</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session854.html
+++ b/spa2019/sessions/session854.html
@@ -49,7 +49,7 @@ Facilitation tips;<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/marijnhuizendveld.html">Marijn Huizendveld</a><i><br>Marijn Huizendveld B.V. </i></li>
+  <li><a href="/spa2019/people/marijnhuizendveld.html">Marijn Huizendveld</a><i><br>Marijn Huizendveld B.V. </i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session855.html
+++ b/spa2019/sessions/session855.html
@@ -58,7 +58,7 @@ Discussion on the benefit of user story mapping in domain discovery and modellin
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/trondhjorteland.html">Trond Hjorteland</a><i><br>Scienta</i></li>
+  <li><a href="/spa2019/people/trondhjorteland.html">Trond Hjorteland</a><i><br>Scienta</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session856.html
+++ b/spa2019/sessions/session856.html
@@ -51,7 +51,7 @@ Adapted practices.<br />
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/johanpeeters.html">Johan Peeters</a><i><br>Johan Peeters bvba</i></li>
+  <li><a href="/spa2019/people/johanpeeters.html">Johan Peeters</a><i><br>Johan Peeters bvba</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session858.html
+++ b/spa2019/sessions/session858.html
@@ -59,9 +59,9 @@ Session outputs are here: <a href="http://www.artechra.com/media/speaking/2019/W
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/eoinwoods.html">Eoin Woods</a><i><br>Endava</i></li>
-  <li><a href="https://spaconference.org/spa2019/people/nickrozanski.html">Nick Rozanski</a><i><br>ICBC Standard Bank</i></li>
-  <li><a href="https://spaconference.org/spa2019/people/andylongshaw.html">Andy Longshaw</a><i><br>Coop Digital</i></li>
+  <li><a href="/spa2019/people/eoinwoods.html">Eoin Woods</a><i><br>Endava</i></li>
+  <li><a href="/spa2019/people/nickrozanski.html">Nick Rozanski</a><i><br>ICBC Standard Bank</i></li>
+  <li><a href="/spa2019/people/andylongshaw.html">Andy Longshaw</a><i><br>Coop Digital</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session859.html
+++ b/spa2019/sessions/session859.html
@@ -61,8 +61,8 @@ An invite to keep in touch and work with us in the future.</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/lucyhunt.html">Lucy Hunt</a><i><br>Lancaster University</i></li>
-  <li><a href="https://spaconference.org/spa2019/people/peggygregory.html">Peggy Gregory</a><i></i></li>
+  <li><a href="/spa2019/people/lucyhunt.html">Lucy Hunt</a><i><br>Lancaster University</i></li>
+  <li><a href="/spa2019/people/peggygregory.html">Peggy Gregory</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session860.html
+++ b/spa2019/sessions/session860.html
@@ -48,8 +48,8 @@ Sharing of the immediate summary on Twitter etc.</p>
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/paulshannon.html">Paul Shannon</a><i><br>eLife Sciences Publications Ltd</i></li>
-  <li><a href="https://spaconference.org/spa2019/people/hibrimarzook.html">Hibri Marzook</a><i><br>Contino</i></li>
+  <li><a href="/spa2019/people/paulshannon.html">Paul Shannon</a><i><br>eLife Sciences Publications Ltd</i></li>
+  <li><a href="/spa2019/people/hibrimarzook.html">Hibri Marzook</a><i><br>Contino</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session861.html
+++ b/spa2019/sessions/session861.html
@@ -57,8 +57,8 @@ We connect your - the participant's - desire to effectively take something (from
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/wimheemskerk.html">Wim Heemskerk</a><i><br>Beyond Agile</i></li>
-  <li><a href="https://spaconference.org/spa2019/people/eddybruin.html">Eddy Bruin</a><i><br>Loop Forward</i></li>
+  <li><a href="/spa2019/people/wimheemskerk.html">Wim Heemskerk</a><i><br>Beyond Agile</i></li>
+  <li><a href="/spa2019/people/eddybruin.html">Eddy Bruin</a><i><br>Loop Forward</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session864.html
+++ b/spa2019/sessions/session864.html
@@ -19,7 +19,7 @@ include("../programme_includes/session_header.html");
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/aygulzagidullina.html">Aygul Zagidullina</a><i></i></li>
+  <li><a href="/spa2019/people/aygulzagidullina.html">Aygul Zagidullina</a><i></i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");

--- a/spa2019/sessions/session877.html
+++ b/spa2019/sessions/session877.html
@@ -39,7 +39,7 @@ I hope to inspire attendees to consider creating more automated tests and adhere
 
 <h2>Presenters</h2>
 <ol>
-  <li><a href="https://spaconference.org/spa2019/people/raulrodriguez.html">Raul Rodriguez</a><i><br>Zuhlke Engineering</i></li>
+  <li><a href="/spa2019/people/raulrodriguez.html">Raul Rodriguez</a><i><br>Zuhlke Engineering</i></li>
 </ol>
 <?php
 include("../programme_includes/footer.html");


### PR DESCRIPTION
Currently, the previous spa sites are hosted at http://www.spaconference-history.org/ meaning that any absolute links to http://www.spaconference.org do not work.

This PR updates absolute links to relative links, allowing them to work with the current URL. It is only links within the programme and session pages for now and only for SPA2018 and SPA2019.

It has already been deployed to the server.