### PR TITLE
Remove absolute SPA links from OT sites

### DIFF
--- a/ot2000/index.html
+++ b/ot2000/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-   <meta http-equiv="REFRESH" content="0; url=http://www.spaconference.org/ot2000/index.htm">
+   <meta http-equiv="REFRESH" content="0; url=/ot2000/index.htm">
   <title>OT2000</title>
 </head>
 <body nosave>

--- a/ot2001/index.html
+++ b/ot2001/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-   <meta http-equiv="REFRESH" content="0; url=http://www.spaconference.org/ot2001/index.htm">
+   <meta http-equiv="REFRESH" content="0; url=/ot2001/index.htm">
   <title>OT2001</title>
 </head>
 <body nosave>

--- a/ot2002/index.html
+++ b/ot2002/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-   <meta http-equiv="REFRESH" content="0; url=http://www.spaconference.org/ot2002/index.htm">
+   <meta http-equiv="REFRESH" content="0; url=/ot2002/index.htm">
   <title>OT2002</title>
 </head>
 <body nosave>

--- a/ot2003/index.html
+++ b/ot2003/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-   <meta http-equiv="REFRESH" content="0; url=http://www.spaconference.org/ot2003/index.htm">
+   <meta http-equiv="REFRESH" content="0; url=/ot2003/index.htm">
   <title>OT2003</title>
 </head>
 <body nosave>

--- a/ot2004/People.html
+++ b/ot2004/People.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-   <meta http-equiv="REFRESH" content="0; url=http://www.spaconference.org/ot2004/people.shtml">
+   <meta http-equiv="REFRESH" content="0; url=/ot2004/people.shtml">
   <title>OT2004 - People</title>
 </head>
 <body nosave>

--- a/ot2004/Programme1836.html
+++ b/ot2004/Programme1836.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 
-<!-- saved from url=(0044)http://www.spaconference.org/ot2004/programmeTemplate.html -->
+<!-- saved from url=(0044)/ot2004/programmeTemplate.html -->
 <!-- OT Programme Template (magic phrase -- leave this line in) -->
 <HTML>
 <HEAD>
@@ -73,7 +73,7 @@
 					</div>
 				</td>
 				<td>
-					<H4><A href="http://www.spaconference.org/ot2004/"></A>Session Types</H4>
+					<H4><A href="/ot2004/"></A>Session Types</H4>
 						<P>
 							<TABLE id="Table4" border="0">
 								<TR>
@@ -116,9 +116,9 @@
 					</P>
 				</TD>
 	
-				<TD class="item" rowSpan="1"><font size=-2>WG1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaecabhcoproxyfavayacomKk" target=session><b>Seeing the forest and the trees </b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KrisLalumiere&type=bio" target=person>Kris&nbsp;Lalumiere</a> <i>Independent&nbsp;consultant</i></TD>
-				<TD class="item" rowSpan="1"><font size=-2>WG2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaefehbmadonnacswincolostateeduKk" target=session><b>Process Engineering workshop</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BrianHendersonSellers&type=bio" target=person>Brian&nbsp;Henderson-Sellers</a> <i>University&nbsp;of Technology, Sydney</i></TD>
-				<TD class="item" rowSpan="1"><font size=-2>WG3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcabhifgcibaabfcKk" target=session><b>Getting the message?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DavidBell&type=bio" target=person>David&nbsp;Bell</a> <i>MFESD</i></TD>
+				<TD class="item" rowSpan="1"><font size=-2>WG1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaecabhcoproxyfavayacomKk" target=session><b>Seeing the forest and the trees </b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=KrisLalumiere&type=bio" target=person>Kris&nbsp;Lalumiere</a> <i>Independent&nbsp;consultant</i></TD>
+				<TD class="item" rowSpan="1"><font size=-2>WG2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaefehbmadonnacswincolostateeduKk" target=session><b>Process Engineering workshop</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BrianHendersonSellers&type=bio" target=person>Brian&nbsp;Henderson-Sellers</a> <i>University&nbsp;of Technology, Sydney</i></TD>
+				<TD class="item" rowSpan="1"><font size=-2>WG3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcabhifgcibaabfcKk" target=session><b>Getting the message?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DavidBell&type=bio" target=person>David&nbsp;Bell</a> <i>MFESD</i></TD>
 				<TD class="item" rowSpan="1"></TD>
 				<TD class="item" rowSpan="1"></TD>
 			</TR>
@@ -127,7 +127,7 @@
 					<P>19:30<BR>
 						22:00</P>
 				</TD>
-				<TD class="break" colSpan="5">Reception with buffet sponsored by <A href="http://www.spaconference.org/cgi-bin/wiki.pl/?ThoughtWorks">
+				<TD class="break" colSpan="5">Reception with buffet sponsored by <A href="/cgi-bin/wiki.pl/?ThoughtWorks">
 						ThoughtWorks</A></TD>
 			</TR>
 			<TR vAlign="top">
@@ -159,17 +159,17 @@
 			<TR vAlign="top">
 				<TD class="time">09:45<BR>
 					11:00</TD>
-				<TD class="item" rowSpan="2"><font size=-2></font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcefjhbihostibbfcbcagdrangeibbfcbtcentralpluscomKk" target=session><b>Objects on ACID</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NicholasSimons&type=bio" target=person>Nicholas&nbsp;Simons</a> <i>Metamaxim&nbsp;Ltd.</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2></font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcbhafajbgjhbfaeeKk" target=session><b>JPMorgan Case  Study: Deploying a Process Framework</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=FrancisEldergill&type=bio" target=person>Francis&nbsp;Eldergill</a> <i></i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbafheacijchostcbhdjjjjinaddrbtopenworldcomKk" target=session><b>Customer Taming</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NigelGilkes&type=bio" target=person>Nigel&nbsp;Gilkes</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
-				<TD class="item"><font size=-2>WS13</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifdgefKk" target=session><b>Personality Traits: Do I have any?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JaneChandler&type=bio" target=person>Jane&nbsp;Chandler</a> <i>University&nbsp;of Portsmouth</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JanetCarter&type=bio" target=person>Janet&nbsp;Carter</a> <i>University&nbsp;of Kent at Canterbury</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IanBenest&type=bio" target=person>Ian&nbsp;Benest</a> <i>University&nbsp;of York</i></TD>
-				<TD class="item"><font size=-2>TU2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaedjeamadonnacswincolostateeduKk" target=session><b>Understanding Metamodelling</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BrianHendersonSellers&type=bio" target=person>Brian&nbsp;Henderson-Sellers</a> <i>University&nbsp;of Technology, Sydney</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2></font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcefjhbihostibbfcbcagdrangeibbfcbtcentralpluscomKk" target=session><b>Objects on ACID</b></a><br><a href="/cgi-bin/wiki.pl/?browse=NicholasSimons&type=bio" target=person>Nicholas&nbsp;Simons</a> <i>Metamaxim&nbsp;Ltd.</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2></font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcbhafajbgjhbfaeeKk" target=session><b>JPMorgan Case  Study: Deploying a Process Framework</b></a><br><a href="/cgi-bin/wiki.pl/?browse=FrancisEldergill&type=bio" target=person>Francis&nbsp;Eldergill</a> <i></i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbafheacijchostcbhdjjjjinaddrbtopenworldcomKk" target=session><b>Customer Taming</b></a><br><a href="/cgi-bin/wiki.pl/?browse=NigelGilkes&type=bio" target=person>Nigel&nbsp;Gilkes</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
+				<TD class="item"><font size=-2>WS13</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifdgefKk" target=session><b>Personality Traits: Do I have any?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JaneChandler&type=bio" target=person>Jane&nbsp;Chandler</a> <i>University&nbsp;of Portsmouth</i>, <a href="/cgi-bin/wiki.pl/?browse=JanetCarter&type=bio" target=person>Janet&nbsp;Carter</a> <i>University&nbsp;of Kent at Canterbury</i>, <a href="/cgi-bin/wiki.pl/?browse=IanBenest&type=bio" target=person>Ian&nbsp;Benest</a> <i>University&nbsp;of York</i></TD>
+				<TD class="item"><font size=-2>TU2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaedjeamadonnacswincolostateeduKk" target=session><b>Understanding Metamodelling</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BrianHendersonSellers&type=bio" target=person>Brian&nbsp;Henderson-Sellers</a> <i>University&nbsp;of Technology, Sydney</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">11:30<BR>
 					12:45</TD>
-				<TD class="item"><font size=-2>CS1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcedbbbhostibbciceibbhinaddrbtopenworldcomKk" target=session><b>The Compute Backbone at JPMorgan</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterSumner&type=bio" target=person>Peter&nbsp;Sumner</a> <i>JPMorgan</i></TD>
-				<TD class="item"><font size=-2>TU9</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcegfKk" target=session><b>The Application Reference Model</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnCheesman&type=bio" target=person>John&nbsp;Cheesman</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=GregHodgkinson&type=bio" target=person>Greg&nbsp;Hodgkinson</a> <i></i></TD>
+				<TD class="item"><font size=-2>CS1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcedbbbhostibbciceibbhinaddrbtopenworldcomKk" target=session><b>The Compute Backbone at JPMorgan</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PeterSumner&type=bio" target=person>Peter&nbsp;Sumner</a> <i>JPMorgan</i></TD>
+				<TD class="item"><font size=-2>TU9</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcegfKk" target=session><b>The Application Reference Model</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnCheesman&type=bio" target=person>John&nbsp;Cheesman</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=GregHodgkinson&type=bio" target=person>Greg&nbsp;Hodgkinson</a> <i></i></TD>
 			<TR vAlign="top">
 				<TD class="time">12:45&nbsp;<BR>
 					13:45</TD>
@@ -178,11 +178,11 @@
 			<TR vAlign="top">
 				<TD class="time">13:45<BR>
 					15:00</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccgajdkeithbraithwaitedemoncoukKk" target=session><b>How I learned to stop worrying and love metrics</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>IvanMoore</a> <i>ThoughtWorks</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdicfcafhostibbdebhdjfinaddrbtopenworldcomKk" target=session><b>Generic Mechanisms in Software Engineering</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KieranMockford&type=bio" target=person>Kieran&nbsp;Mockford</a> <i></i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS5</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdadfhhecoproxyfavayacomKk" target=session><b>Systems archetypes -- diagnosing system issues and designing high-leverage interventions</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KrisLalumiere&type=bio" target=person>Kris&nbsp;Lalumiere</a> <i>Independent&nbsp;consultant</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS16</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagegehhgidslcbhbffcaabcbzencoukKk" target=session><b>The Software Value Chain</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DavidHarvey&type=bio" target=person>David&nbsp;Harvey</a> <i>UBS&nbsp;Investment Bank</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>Peter&nbsp;Marks</a> <i>Digita</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS7</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbcahedgccdccdhaKk" target=session><b>Mind the culture gap!</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AliaCooper&type=bio" target=person>Alia&nbsp;Cooper</a> <i>Tesco</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccgajdkeithbraithwaitedemoncoukKk" target=session><b>How I learned to stop worrying and love metrics</b></a><br><a href="/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i>, <a href="/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>IvanMoore</a> <i>ThoughtWorks</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdicfcafhostibbdebhdjfinaddrbtopenworldcomKk" target=session><b>Generic Mechanisms in Software Engineering</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="/cgi-bin/wiki.pl/?browse=KieranMockford&type=bio" target=person>Kieran&nbsp;Mockford</a> <i></i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS5</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdadfhhecoproxyfavayacomKk" target=session><b>Systems archetypes -- diagnosing system issues and designing high-leverage interventions</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=KrisLalumiere&type=bio" target=person>Kris&nbsp;Lalumiere</a> <i>Independent&nbsp;consultant</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS16</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagegehhgidslcbhbffcaabcbzencoukKk" target=session><b>The Software Value Chain</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DavidHarvey&type=bio" target=person>David&nbsp;Harvey</a> <i>UBS&nbsp;Investment Bank</i>, <a href="/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>Peter&nbsp;Marks</a> <i>Digita</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS7</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbcahedgccdccdhaKk" target=session><b>Mind the culture gap!</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AliaCooper&type=bio" target=person>Alia&nbsp;Cooper</a> <i>Tesco</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">15:30&nbsp;<BR>
@@ -198,7 +198,7 @@
 			<TR>
 				<TD class="time" height="34">18:15<BR>
 					19:15</TD>
-				<TD class="break" colSpan="5" height="36"><font size=-2>PL1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifbijaKk" target=session><b>An Evening with Ivar Jacobson</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvarJacobson&type=bio" target=person>Ivar&nbsp;Jacobson</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i><A href="http://www.spaconference.org/ot2004/IvarSession.html"></A></TD>
+				<TD class="break" colSpan="5" height="36"><font size=-2>PL1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifbijaKk" target=session><b>An Evening with Ivar Jacobson</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IvarJacobson&type=bio" target=person>Ivar&nbsp;Jacobson</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i><A href="/ot2004/IvarSession.html"></A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">19:15<BR>
@@ -209,7 +209,7 @@
 				<TD class="time">20:45&nbsp;
 					<BR>
 					21:45</TD>
-				<TD class="plenary" colSpan="5"><font size=-2>XX2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifdccdKk" target=session><b>DynaBoF</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i></TD>
+				<TD class="plenary" colSpan="5"><font size=-2>XX2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifdccdKk" target=session><b>DynaBoF</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">21:45&nbsp;
@@ -244,45 +244,45 @@
 				<TD class="time">09:00&nbsp;<BR>
 					10:00</TD>
 				<TD class="plenary" colSpan="5">
-					<P align="left"><font size=-2>PL2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifbehhKk" target=session><b>Software Design in the Twenty-first Century</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i></i></P>
+					<P align="left"><font size=-2>PL2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifbehhKk" target=session><b>Software Design in the Twenty-first Century</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i></i></P>
 				</TD>
 			<TR vAlign="top">
 				<TD class="time">10:15&nbsp;<BR>
 					11:30</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS8</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccfbejcacheglutnserverntlinetKk" target=session><b>What went wrong? Error handling in a distributed environment</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndyLongshaw&type=bio" target=person>Andy&nbsp;Longshaw</a> <i>Blue&nbsp;Skyline</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS9</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcbfghctidebdgmicrosoftcomKk" target=session><b>Domain Specific Languages - issues and exercises</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
-				<TD class="item"><font size=-2>WS10</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcjefecbibfbhdceeKk" target=session><b>Belbin Team Roles in Software Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DuncanMcGregor&type=bio" target=person>Duncan&nbsp;McGregor</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RichardCare&type=bio" target=person>Richard&nbsp;Care</a> <i>Octave&nbsp;Associates</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>TU3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagbffdghhcbcbfijfcbaKk" target=session><b>Test Driven Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>Ivan&nbsp;Moore</a> <i>ThoughtWorks</i></TD>
-				<TD class="item"><font size=-2>TU4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdfdbacbdialgcgeccadfaccessuktiscalicomKk" target=session><b>Getting Your Story Straight</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RachelDavies&type=bio" target=person>Rachel&nbsp;Davies</a> <i>Amarinda</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS8</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccfbejcacheglutnserverntlinetKk" target=session><b>What went wrong? Error handling in a distributed environment</b></a><br><a href="/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i>, <a href="/cgi-bin/wiki.pl/?browse=AndyLongshaw&type=bio" target=person>Andy&nbsp;Longshaw</a> <i>Blue&nbsp;Skyline</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS9</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcbfghctidebdgmicrosoftcomKk" target=session><b>Domain Specific Languages - issues and exercises</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
+				<TD class="item"><font size=-2>WS10</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcjefecbibfbhdceeKk" target=session><b>Belbin Team Roles in Software Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DuncanMcGregor&type=bio" target=person>Duncan&nbsp;McGregor</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=RichardCare&type=bio" target=person>Richard&nbsp;Care</a> <i>Octave&nbsp;Associates</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>TU3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagbffdghhcbcbfijfcbaKk" target=session><b>Test Driven Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>Ivan&nbsp;Moore</a> <i>ThoughtWorks</i></TD>
+				<TD class="item"><font size=-2>TU4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdfdbacbdialgcgeccadfaccessuktiscalicomKk" target=session><b>Getting Your Story Straight</b></a><br><a href="/cgi-bin/wiki.pl/?browse=RachelDavies&type=bio" target=person>Rachel&nbsp;Davies</a> <i>Amarinda</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">12:00&nbsp;<BR>
 					13:15</TD>
-				<TD class="item"><font size=-2>CS2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagadejijdwansyntropyadslalcomcoukKk" target=session><b>Dispersed Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PaulDyson&type=bio" target=person>Paul&nbsp;Dyson</a> <i>e2x&nbsp;limited</i></TD>
-				<TD class="item"><font size=-2>TU5</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdabcjdapdjeifcfidiptdialinnetKk" target=session><b>Understanding Project Dynamics</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JensColdewey&type=bio" target=person>Jens&nbsp;Coldewey</a> <i>Coldewey&nbsp;Consulting</i></TD>
+				<TD class="item"><font size=-2>CS2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagadejijdwansyntropyadslalcomcoukKk" target=session><b>Dispersed Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i>, <a href="/cgi-bin/wiki.pl/?browse=PaulDyson&type=bio" target=person>Paul&nbsp;Dyson</a> <i>e2x&nbsp;limited</i></TD>
+				<TD class="item"><font size=-2>TU5</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdabcjdapdjeifcfidiptdialinnetKk" target=session><b>Understanding Project Dynamics</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JensColdewey&type=bio" target=person>Jens&nbsp;Coldewey</a> <i>Coldewey&nbsp;Consulting</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">13:15&nbsp;
 					<BR>
 					14:45</TD>
-				<TD class="break" colSpan="5">Lunch and <A href="http://www.spaconference.org/ot2004/bof.html" target="_show">
+				<TD class="break" colSpan="5">Lunch and <A href="/ot2004/bof.html" target="_show">
 						BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">14:45&nbsp;<BR>
 					16:00</TD>
-				<TD class="item"><font size=-2>WS11</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcebbcfbbcjdfibbgKk" target=session><b>A Picture Paints a Thousand Words - Or does it?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MattStephenson&type=bio" target=person>MattStephenson</a> <i>Royal&nbsp;& SunAlliance</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=StephenHutchinson&type=bio" target=person>StephenHutchinson</a> <i>Royal&nbsp;and Sunalliance</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS12</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaegccchostibbcicaadjinaddrbtopenworldcomKk" target=session><b>Towards EJB 3.0</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=ScottCrawford&type=bio" target=person>Scott&nbsp;Crawford</a> <i>Independent</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>SI1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbafjcdhijbdslcbhbffbhegzencoukKk" target=session><b>Tracer Bullets Reloaded</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PaulSimmons&type=bio" target=person>Paul&nbsp;Simmons</a> <i>Rochester&nbsp;Software House</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobWestgeest&type=bio" target=person>Rob&nbsp;Westgeest</a> <i>Agidem</i></TD>
-				<TD class="item"><font size=-2>CS3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbahecibdibaebfcgcKk" target=session><b>Data distribution in a diverse community - an exercise in abstraction</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IanCornwell&type=bio" target=person>Ian&nbsp;Cornwell</a> <i>Mott&nbsp;MacDonald</i></TD>
-				<TD class="item"><font size=-2>TU10</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcjjeKk" target=session><b>Mock Objects: Driving top-down development.</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JoeWalnes&type=bio" target=person>Joe&nbsp;Walnes</a> <i>ThoughtWorks</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=TimMackinnon&type=bio" target=person>Tim&nbsp;Mackinnon</a> <i>ThoughtWorks</i></TD>
+				<TD class="item"><font size=-2>WS11</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcebbcfbbcjdfibbgKk" target=session><b>A Picture Paints a Thousand Words - Or does it?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MattStephenson&type=bio" target=person>MattStephenson</a> <i>Royal&nbsp;& SunAlliance</i>, <a href="/cgi-bin/wiki.pl/?browse=StephenHutchinson&type=bio" target=person>StephenHutchinson</a> <i>Royal&nbsp;and Sunalliance</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS12</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaegccchostibbcicaadjinaddrbtopenworldcomKk" target=session><b>Towards EJB 3.0</b></a><br><a href="/cgi-bin/wiki.pl/?browse=ScottCrawford&type=bio" target=person>Scott&nbsp;Crawford</a> <i>Independent</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>SI1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbafjcdhijbdslcbhbffbhegzencoukKk" target=session><b>Tracer Bullets Reloaded</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PaulSimmons&type=bio" target=person>Paul&nbsp;Simmons</a> <i>Rochester&nbsp;Software House</i>, <a href="/cgi-bin/wiki.pl/?browse=RobWestgeest&type=bio" target=person>Rob&nbsp;Westgeest</a> <i>Agidem</i></TD>
+				<TD class="item"><font size=-2>CS3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbahecibdibaebfcgcKk" target=session><b>Data distribution in a diverse community - an exercise in abstraction</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IanCornwell&type=bio" target=person>Ian&nbsp;Cornwell</a> <i>Mott&nbsp;MacDonald</i></TD>
+				<TD class="item"><font size=-2>TU10</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcjjeKk" target=session><b>Mock Objects: Driving top-down development.</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JoeWalnes&type=bio" target=person>Joe&nbsp;Walnes</a> <i>ThoughtWorks</i>, <a href="/cgi-bin/wiki.pl/?browse=TimMackinnon&type=bio" target=person>Tim&nbsp;Mackinnon</a> <i>ThoughtWorks</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">16:30&nbsp;<BR>
 					17:45</TD>
-				<TD class="item"><font size=-2>GB1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbefifhdslcbhbffcaagezencoukKk" target=session><b>MDA - this year's silver bullet?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DanHaywood&type=bio" target=person>Dan&nbsp;Haywood</a> <i>Haywood&nbsp;Associates Ltd.</i></TD>
-				<TD class="item"><font size=-2>TT1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagejfjjagdslcbhbffbibcfezencoukKk" target=session><b>Radical Computing</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>PeterMarks</a> <i>Digita</i></TD>
-				<TD class="item"><font size=-2>WS14</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdadeagcpcpabhebbbjpcshowardabmdcomcastnetKk" target=session><b>Blogs and RSS - worth your time?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JamesRobertson&type=bio" target=person>James&nbsp;Robertson</a> <i>Cincom&nbsp;Systems, Inc.</i></TD>
+				<TD class="item"><font size=-2>GB1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbefifhdslcbhbffcaagezencoukKk" target=session><b>MDA - this year's silver bullet?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DanHaywood&type=bio" target=person>Dan&nbsp;Haywood</a> <i>Haywood&nbsp;Associates Ltd.</i></TD>
+				<TD class="item"><font size=-2>TT1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagejfjjagdslcbhbffbibcfezencoukKk" target=session><b>Radical Computing</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>PeterMarks</a> <i>Digita</i></TD>
+				<TD class="item"><font size=-2>WS14</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdadeagcpcpabhebbbjpcshowardabmdcomcastnetKk" target=session><b>Blogs and RSS - worth your time?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JamesRobertson&type=bio" target=person>James&nbsp;Robertson</a> <i>Cincom&nbsp;Systems, Inc.</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">18:15&nbsp;<BR>
@@ -298,7 +298,7 @@
 				<TD class="time">20:45&nbsp;<BR>
 					21:45</TD>
 				<TD class="plenary" colSpan="2">Diversions</TD>
-				<TD class="plenary" colSpan="3"><A href="http://www.spaconference.org/ot2004/bof.shtml" target="_show">BOF 
+				<TD class="plenary" colSpan="3"><A href="/ot2004/bof.shtml" target="_show">BOF 
 						sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
@@ -329,22 +329,22 @@
 			<TR vAlign="top">
 				<TD class="time">09:00&nbsp;<BR>
 					10:00</TD>
-				<TD class="plenary" colSpan="5"><font size=-2>PL3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcjbiKk" target=session><b>How to Design a Good API and Why it Matters</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JoshuaBloch&type=bio" target=person>Joshua&nbsp;Bloch</a> <i></i></TD>
+				<TD class="plenary" colSpan="5"><font size=-2>PL3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcjbiKk" target=session><b>How to Design a Good API and Why it Matters</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JoshuaBloch&type=bio" target=person>Joshua&nbsp;Bloch</a> <i></i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">10:15&nbsp;<BR>
 					11:30</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS15</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcejhiebhostibbdgcbjhainaddrbtopenworldcomKk" target=session><b>Discovery Made Easy</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BernardHoran&type=bio" target=person>Bernard&nbsp;Horan</a> <i>Sun&nbsp;Microsystems</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=LauraHill&type=bio" target=person>Laura&nbsp;Hill</a> <i>Sun&nbsp;Microsystems</i></TD>
-				<TD class="item"><font size=-2>TT2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcahicdproxybdraegercomKk" target=session><b>Sustainable Architecture</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KlausMarquardt&type=bio" target=person>Klaus&nbsp;Marquardt</a> <i>Dräger&nbsp;Medical AG</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS6</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccgfccbjchgbgciKk" target=session><b>The Software Engineer's View of Content Management</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndreasRping&type=bio" target=person>Andreas&nbsp;Rüping</a> <i>sd&m&nbsp;AG, Hamburg, Germany</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS17</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcfdgabgcachedlbaproxyaolcomKk" target=session><b>Non-XP words for agile development practices</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AlistairCockburn&type=bio" target=person>Alistair&nbsp;Cockburn</a> <i>Humans&nbsp;and Technology</i></TD>
-				<TD class="item"><font size=-2>TU7</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagddabcjhbjdbaihibaKk" target=session><b>Strategies for building conceptual models of legacy & vendor software</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobJames&type=bio" target=person>Rob&nbsp;James</a> <i>HSBC</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS15</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcejhiebhostibbdgcbjhainaddrbtopenworldcomKk" target=session><b>Discovery Made Easy</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BernardHoran&type=bio" target=person>Bernard&nbsp;Horan</a> <i>Sun&nbsp;Microsystems</i>, <a href="/cgi-bin/wiki.pl/?browse=LauraHill&type=bio" target=person>Laura&nbsp;Hill</a> <i>Sun&nbsp;Microsystems</i></TD>
+				<TD class="item"><font size=-2>TT2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcahicdproxybdraegercomKk" target=session><b>Sustainable Architecture</b></a><br><a href="/cgi-bin/wiki.pl/?browse=KlausMarquardt&type=bio" target=person>Klaus&nbsp;Marquardt</a> <i>Dräger&nbsp;Medical AG</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS6</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccgfccbjchgbgciKk" target=session><b>The Software Engineer's View of Content Management</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AndreasRping&type=bio" target=person>Andreas&nbsp;Rüping</a> <i>sd&m&nbsp;AG, Hamburg, Germany</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS17</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcfdgabgcachedlbaproxyaolcomKk" target=session><b>Non-XP words for agile development practices</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AlistairCockburn&type=bio" target=person>Alistair&nbsp;Cockburn</a> <i>Humans&nbsp;and Technology</i></TD>
+				<TD class="item"><font size=-2>TU7</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagddabcjhbjdbaihibaKk" target=session><b>Strategies for building conceptual models of legacy & vendor software</b></a><br><a href="/cgi-bin/wiki.pl/?browse=RobJames&type=bio" target=person>Rob&nbsp;James</a> <i>HSBC</i></TD>
 			</TR>
 			<TR>
 				<TD class="time">12:00<BR>
 					13:15</TD>
-				<TD class="item"><font size=-2>TU6</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdicacighostibbdebhdjfinaddrbtopenworldcomKk" target=session><b>Considerations for Code Placement in a Layered Architecture</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KieranMockford&type=bio" target=person>Kieran&nbsp;Mockford</a> <i></i></TD>
-				<TD class="item"><font size=-2>TU8</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcgjghjccbhcahbhabhiKk" target=session><b>Taming the Tiger: Using Java 1.5</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BenedictHeal&type=bio" target=person>Benedict&nbsp;Heal</a> <i>Fastnloose&nbsp;Ltd</i></TD>
+				<TD class="item"><font size=-2>TU6</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdicacighostibbdebhdjfinaddrbtopenworldcomKk" target=session><b>Considerations for Code Placement in a Layered Architecture</b></a><br><a href="/cgi-bin/wiki.pl/?browse=KieranMockford&type=bio" target=person>Kieran&nbsp;Mockford</a> <i></i></TD>
+				<TD class="item"><font size=-2>TU8</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcgjghjccbhcahbhabhiKk" target=session><b>Taming the Tiger: Using Java 1.5</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BenedictHeal&type=bio" target=person>Benedict&nbsp;Heal</a> <i>Fastnloose&nbsp;Ltd</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">13:15&nbsp;<BR>
@@ -354,10 +354,10 @@
 			<TR vAlign="top">
 				<TD class="time">14:15&nbsp;<BR>
 					15:30</TD>
-				<TD class="item"><font size=-2>TT3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdhchjcgcbdhihibigKk" target=session><b>Component co-ordination in models</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RichardMitchell&type=bio" target=person>Richard&nbsp;Mitchell</a> <i>InferData&nbsp;Corporation</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobJames&type=bio" target=person>Rob&nbsp;James</a> <i>HSBC</i></TD>
-				<TD class="item"><font size=-2>WS18</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcbhfdakeithbraithwaitedemoncoukKk" target=session><b>How to Fail at XP</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=SteveFreeman&type=bio" target=person>SteveFreeman</a> <i>M3P</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i></TD>
-				<TD class="item"><font size=-2>XX1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndyCarmichaelchairmanonly&type=bio" target=person>Andy&nbsp;Carmichael&nbsp;(chairman&nbsp;only)</a> <i></i></TD>
-				<TD class="item"><font size=-2>CS4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbccgfespringbankhudacukKk" target=session><b>The difficulties we encountered in developing an object model to support requirements development.</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=SteveWade&type=bio" target=person>Steve&nbsp;Wade</a> <i>University&nbsp;of Huddersfield</i></TD>
+				<TD class="item"><font size=-2>TT3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdhchjcgcbdhihibigKk" target=session><b>Component co-ordination in models</b></a><br><a href="/cgi-bin/wiki.pl/?browse=RichardMitchell&type=bio" target=person>Richard&nbsp;Mitchell</a> <i>InferData&nbsp;Corporation</i>, <a href="/cgi-bin/wiki.pl/?browse=RobJames&type=bio" target=person>Rob&nbsp;James</a> <i>HSBC</i></TD>
+				<TD class="item"><font size=-2>WS18</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcbhfdakeithbraithwaitedemoncoukKk" target=session><b>How to Fail at XP</b></a><br><a href="/cgi-bin/wiki.pl/?browse=SteveFreeman&type=bio" target=person>SteveFreeman</a> <i>M3P</i>, <a href="/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i></TD>
+				<TD class="item"><font size=-2>XX1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AndyCarmichaelchairmanonly&type=bio" target=person>Andy&nbsp;Carmichael&nbsp;(chairman&nbsp;only)</a> <i></i></TD>
+				<TD class="item"><font size=-2>CS4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbccgfespringbankhudacukKk" target=session><b>The difficulties we encountered in developing an object model to support requirements development.</b></a><br><a href="/cgi-bin/wiki.pl/?browse=SteveWade&type=bio" target=person>Steve&nbsp;Wade</a> <i>University&nbsp;of Huddersfield</i></TD>
 				<TD class="item"></TD>
 			</TR>
 			<TR vAlign="top">

--- a/ot2004/index.html
+++ b/ot2004/index.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-   <meta http-equiv="REFRESH" content="0; url=http://www.spaconference.org/ot2004/index.shtml">
+   <meta http-equiv="REFRESH" content="0; url=/ot2004/index.shtml">
   <title>OT2004</title>
 </head>
 <body nosave>

--- a/ot2004/index.shtml
+++ b/ot2004/index.shtml
@@ -40,7 +40,7 @@
 		</div>
 		<h2>Output</h2>
 		<p>
-		OT2004 has now finished. You can <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?OtTwoThousandAndFourOutput">
+		OT2004 has now finished. You can <a href="/cgi-bin/wiki.pl/?OtTwoThousandAndFourOutput">
 		view output from the sessions</a>.
 		</p>
 		<h2>The conference for participants</h2>

--- a/ot2004/output.html
+++ b/ot2004/output.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-   <meta http-equiv="REFRESH" content="0; url="http://www.spaconference.org/cgi-bin/wiki.pl/?OtTwoThousandAndFourOutput">
+   <meta http-equiv="REFRESH" content="0; url="/cgi-bin/wiki.pl/?OtTwoThousandAndFourOutput">
   <title>OT2004 - output from the sessions</title>
 </head>
 <body nosave>

--- a/ot2004/programme.shtml
+++ b/ot2004/programme.shtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 
-<!-- saved from url=(0044)http://www.spaconference.org/ot2004/programmeTemplate.html -->
+<!-- saved from url=(0044)/ot2004/programmeTemplate.html -->
 <!-- OT Programme Template (magic phrase - - leave this line in) -->
 <HTML>
 <HEAD>
@@ -73,7 +73,7 @@
 					</div>
 				</td>
 				<td>
-					<H4><A href="http://www.spaconference.org/ot2004/"></A>Session Types</H4>
+					<H4><A href="/ot2004/"></A>Session Types</H4>
 						<P>
 							<TABLE id="Table4" border="0">
 								<TR>
@@ -116,9 +116,9 @@
 					</P>
 				</TD>
 	
-				<TD class="item" rowSpan="2"><font size=-2>WG1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaecabhcoproxyfavayacomKk" target=session><b>Seeing the forest and the trees </b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WG3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcabhifgcibaabfcKk" target=session><b>Getting the message?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DavidBell&type=bio" target=person>David&nbsp;Bell</a> <i>MFESD</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WG4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbahdfgchbdKk" target=session><b>Xbots</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DuncanPierce&type=bio" target=person>Duncan&nbsp;Pierce</a> <i>Amarinda</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WG1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaecabhcoproxyfavayacomKk" target=session><b>Seeing the forest and the trees </b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WG3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcabhifgcibaabfcKk" target=session><b>Getting the message?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DavidBell&type=bio" target=person>David&nbsp;Bell</a> <i>MFESD</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WG4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbahdfgchbdKk" target=session><b>Xbots</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DuncanPierce&type=bio" target=person>Duncan&nbsp;Pierce</a> <i>Amarinda</i></TD>
 				<TD rowSpan="1"></TD>
 				<TD rowSpan="2"></TD>
 			</TR>
@@ -129,14 +129,14 @@
 					</P>
 				</TD>
 	
-				<TD class="item" rowSpan="1"><font size=-2>TU11</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbahdfgcjfdKk" target=session><b>UML 1++</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i>ThoughtWorks</i></TD>
+				<TD class="item" rowSpan="1"><font size=-2>TU11</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbahdfgcjfdKk" target=session><b>UML 1++</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i>ThoughtWorks</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">
 					<P>19:30<BR>
 						22:00</P>
 				</TD>
-				<TD class="break" colSpan="5">Reception with buffet sponsored by <A href="http://www.spaconference.org/cgi-bin/wiki.pl/?ThoughtWorks">
+				<TD class="break" colSpan="5">Reception with buffet sponsored by <A href="/cgi-bin/wiki.pl/?ThoughtWorks">
 						ThoughtWorks</A></TD>
 			</TR>
 			<TR vAlign="top">
@@ -168,17 +168,17 @@
 			<TR vAlign="top">
 				<TD class="time">09:45<BR>
 					11:00</TD>
-				<TD class="item" rowSpan="2"><font size=-2>TU1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbicbebhainbhexamscomKk" target=session><b>Getting to Grips with Architecture Using Viewpoints and Perspectives</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NickRozanski&type=bio" target=person>Nick&nbsp;Rozanski</a> <i>French&nbsp;Thornton</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagbjhfiejevispcacheabopsasmrabenergisidcnetKk" target=session><b>Delegation in Java</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=ErikGroeneveld&type=bio" target=person>Erik&nbsp;Groeneveld</a> <i>Seek&nbsp;You Too B.V.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=WillemvandenEnde&type=bio" target=person>Willem&nbsp;van&nbsp;den&nbsp;Ende</a> <i>CQ2</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbafheacijchostcbhdjjjjinaddrbtopenworldcomKk" target=session><b>How to Win Friends and Influence People</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NigelGilkes&type=bio" target=person>Nigel&nbsp;Gilkes</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
-				<TD class="item"><font size=-2>WS13</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifdgefKk" target=session><b>Personality Traits: Do I have any?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JaneChandler&type=bio" target=person>Jane&nbsp;Chandler</a> <i>University&nbsp;of Portsmouth</i></TD>
-				<TD class="item"><font size=-2>TU10</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcjjeKk" target=session><b>Mock Objects: Driving top-down development.</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JoeWalnes&type=bio" target=person>Joe&nbsp;Walnes</a> <i>ThoughtWorks</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NatPryce&type=bio" target=person>Nat&nbsp;Pryce</a> <i>B13media&nbsp;Ltd.</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>TU1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbicbebhainbhexamscomKk" target=session><b>Getting to Grips with Architecture Using Viewpoints and Perspectives</b></a><br><a href="/cgi-bin/wiki.pl/?browse=NickRozanski&type=bio" target=person>Nick&nbsp;Rozanski</a> <i>French&nbsp;Thornton</i>, <a href="/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagbjhfiejevispcacheabopsasmrabenergisidcnetKk" target=session><b>Delegation in Java</b></a><br><a href="/cgi-bin/wiki.pl/?browse=ErikGroeneveld&type=bio" target=person>Erik&nbsp;Groeneveld</a> <i>Seek&nbsp;You Too B.V.</i>, <a href="/cgi-bin/wiki.pl/?browse=WillemvandenEnde&type=bio" target=person>Willem&nbsp;van&nbsp;den&nbsp;Ende</a> <i>CQ2</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbafheacijchostcbhdjjjjinaddrbtopenworldcomKk" target=session><b>How to Win Friends and Influence People</b></a><br><a href="/cgi-bin/wiki.pl/?browse=NigelGilkes&type=bio" target=person>Nigel&nbsp;Gilkes</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
+				<TD class="item"><font size=-2>WS13</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifdgefKk" target=session><b>Personality Traits: Do I have any?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JaneChandler&type=bio" target=person>Jane&nbsp;Chandler</a> <i>University&nbsp;of Portsmouth</i></TD>
+				<TD class="item"><font size=-2>TU10</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcjjeKk" target=session><b>Mock Objects: Driving top-down development.</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JoeWalnes&type=bio" target=person>Joe&nbsp;Walnes</a> <i>ThoughtWorks</i>, <a href="/cgi-bin/wiki.pl/?browse=NatPryce&type=bio" target=person>Nat&nbsp;Pryce</a> <i>B13media&nbsp;Ltd.</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">11:30<BR>
 					12:45</TD>
-				<TD class="item"><font size=-2>CS1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcedbbbhostibbciceibbhinaddrbtopenworldcomKk" target=session><b>The Compute Backbone at JPMorgan</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterSumner&type=bio" target=person>Peter&nbsp;Sumner</a> <i>JPMorgan</i></TD>
-				<TD class="item"><font size=-2>TU9</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcegfKk" target=session><b>The Application Reference Model</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnCheesman&type=bio" target=person>John&nbsp;Cheesman</a> <i>7irene</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=GregHodgkinson&type=bio" target=person>Greg&nbsp;Hodgkinson</a> <i>7irene</i></TD>
+				<TD class="item"><font size=-2>CS1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcedbbbhostibbciceibbhinaddrbtopenworldcomKk" target=session><b>The Compute Backbone at JPMorgan</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PeterSumner&type=bio" target=person>Peter&nbsp;Sumner</a> <i>JPMorgan</i></TD>
+				<TD class="item"><font size=-2>TU9</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcegfKk" target=session><b>The Application Reference Model</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnCheesman&type=bio" target=person>John&nbsp;Cheesman</a> <i>7irene</i>, <a href="/cgi-bin/wiki.pl/?browse=GregHodgkinson&type=bio" target=person>Greg&nbsp;Hodgkinson</a> <i>7irene</i></TD>
 			<TR vAlign="top">
 				<TD class="time">12:45&nbsp;<BR>
 					13:45</TD>
@@ -187,11 +187,11 @@
 			<TR vAlign="top">
 				<TD class="time">13:45<BR>
 					15:00</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccgajdkeithbraithwaitedemoncoukKk" target=session><b>How I learned to stop worrying and love metrics</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>IvanMoore</a> <i>ThoughtWorks</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdicfcafhostibbdebhdjfinaddrbtopenworldcomKk" target=session><b>Generic Mechanisms in Software Engineering</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=SimonDavies&type=bio" target=person>Simon&nbsp;Davies</a> <i>Microsoft</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS5</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdadfhhecoproxyfavayacomKk" target=session><b>Systems archetypes -- diagnosing system issues and designing high-leverage interventions</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>CS3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbahecibdibaebfcgcKk" target=session><b>Data distribution in a diverse community</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IanCornwell&type=bio" target=person>Ian&nbsp;Cornwell</a> <i>Mott&nbsp;MacDonald</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS7</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbcahedgccdccdhaKk" target=session><b>Mind the culture gap!</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AliaCooper&type=bio" target=person>Alia&nbsp;Cooper</a> <i>Tesco</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=HelenSharp&type=bio" target=person>Helen&nbsp;Sharp</a> <i>The&nbsp;Open University</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccgajdkeithbraithwaitedemoncoukKk" target=session><b>How I learned to stop worrying and love metrics</b></a><br><a href="/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i>, <a href="/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>IvanMoore</a> <i>ThoughtWorks</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdicfcafhostibbdebhdjfinaddrbtopenworldcomKk" target=session><b>Generic Mechanisms in Software Engineering</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="/cgi-bin/wiki.pl/?browse=SimonDavies&type=bio" target=person>Simon&nbsp;Davies</a> <i>Microsoft</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS5</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdadfhhecoproxyfavayacomKk" target=session><b>Systems archetypes -- diagnosing system issues and designing high-leverage interventions</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>CS3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbahecibdibaebfcgcKk" target=session><b>Data distribution in a diverse community</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IanCornwell&type=bio" target=person>Ian&nbsp;Cornwell</a> <i>Mott&nbsp;MacDonald</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS7</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbcahedgccdccdhaKk" target=session><b>Mind the culture gap!</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AliaCooper&type=bio" target=person>Alia&nbsp;Cooper</a> <i>Tesco</i>, <a href="/cgi-bin/wiki.pl/?browse=HelenSharp&type=bio" target=person>Helen&nbsp;Sharp</a> <i>The&nbsp;Open University</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">15:30&nbsp;<BR>
@@ -207,7 +207,7 @@
 			<TR>
 				<TD class="time" height="34">18:15<BR>
 					19:15</TD>
-				<TD class="break" colSpan="5" height="36"><font size=-2>PL1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifbijaKk" target=session><b>An Evening with Ivar Jacobson</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvarJacobson&type=bio" target=person>Ivar&nbsp;Jacobson</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i><A href="http://www.spaconference.org/ot2004/IvarSession.html"></A></TD>
+				<TD class="break" colSpan="5" height="36"><font size=-2>PL1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifbijaKk" target=session><b>An Evening with Ivar Jacobson</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IvarJacobson&type=bio" target=person>Ivar&nbsp;Jacobson</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i><A href="/ot2004/IvarSession.html"></A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">19:15<BR>
@@ -218,14 +218,14 @@
 				<TD class="time">20:45&nbsp;
 					<BR>
 					21:45</TD>
-				<TD class="plenary" colSpan="5"><font size=-2>XX2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifdccdKk" target=session><b>DynaBoF</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i></TD>
+				<TD class="plenary" colSpan="5"><font size=-2>XX2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifdccdKk" target=session><b>DynaBoF</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">21:45&nbsp;
 					<BR>
 					22:45</TD>
 				<TD class="plenary" colSpan="2">Diversions</TD>
-				<TD class="plenary" colSpan="3"><A href="http://www.spaconference.org/ot2004/bof.shtml">BOF sessions</A></TD>
+				<TD class="plenary" colSpan="3"><A href="/ot2004/bof.shtml">BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time"></TD>
@@ -254,44 +254,44 @@
 				<TD class="time">09:00&nbsp;<BR>
 					10:00</TD>
 				<TD class="plenary" colSpan="5">
-					<P align="left"><font size=-2>PL2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifbehhKk" target=session><b>Software Design in the Twenty-first Century</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i>ThoughtWorks</i></P>
+					<P align="left"><font size=-2>PL2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifbehhKk" target=session><b>Software Design in the Twenty-first Century</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i>ThoughtWorks</i></P>
 				</TD>
 			<TR vAlign="top">
 				<TD class="time">10:15&nbsp;<BR>
 					11:30</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS8</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccfbejcacheglutnserverntlinetKk" target=session><b>What went wrong? Error handling in a distributed environment</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndyLongshaw&type=bio" target=person>Andy&nbsp;Longshaw</a> <i>Blue&nbsp;Skyline</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS9</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcbfghctidebdgmicrosoftcomKk" target=session><b>Domain Specific Languages - issues and exercises</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
-				<TD class="item"><font size=-2>WS10</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcjefecbibfbhdceeKk" target=session><b>Belbin Team Roles in Software Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DuncanMcGregor&type=bio" target=person>Duncan&nbsp;McGregor</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RichardCare&type=bio" target=person>Richard&nbsp;Care</a> <i>Octave&nbsp;Associates</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>TU3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagbffdghhcbcbfijfcbaKk" target=session><b>Test Driven Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>Ivan&nbsp;Moore</a> <i>ThoughtWorks</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DuncanPierce&type=bio" target=person>Duncan&nbsp;Pierce</a> <i>Amarinda</i></TD>
-				<TD class="item"><font size=-2>TU4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdfdbacbdialgcgeccadfaccessuktiscalicomKk" target=session><b>Getting Your Story Straight</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RachelDavies&type=bio" target=person>Rachel&nbsp;Davies</a> <i>Agile&nbsp;Experience</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS8</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccfbejcacheglutnserverntlinetKk" target=session><b>What went wrong? Error handling in a distributed environment</b></a><br><a href="/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i>, <a href="/cgi-bin/wiki.pl/?browse=AndyLongshaw&type=bio" target=person>Andy&nbsp;Longshaw</a> <i>Blue&nbsp;Skyline</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS9</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcbfghctidebdgmicrosoftcomKk" target=session><b>Domain Specific Languages - issues and exercises</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
+				<TD class="item"><font size=-2>WS10</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcjefecbibfbhdceeKk" target=session><b>Belbin Team Roles in Software Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DuncanMcGregor&type=bio" target=person>Duncan&nbsp;McGregor</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=RichardCare&type=bio" target=person>Richard&nbsp;Care</a> <i>Octave&nbsp;Associates</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>TU3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagbffdghhcbcbfijfcbaKk" target=session><b>Test Driven Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>Ivan&nbsp;Moore</a> <i>ThoughtWorks</i>, <a href="/cgi-bin/wiki.pl/?browse=DuncanPierce&type=bio" target=person>Duncan&nbsp;Pierce</a> <i>Amarinda</i></TD>
+				<TD class="item"><font size=-2>TU4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdfdbacbdialgcgeccadfaccessuktiscalicomKk" target=session><b>Getting Your Story Straight</b></a><br><a href="/cgi-bin/wiki.pl/?browse=RachelDavies&type=bio" target=person>Rachel&nbsp;Davies</a> <i>Agile&nbsp;Experience</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">12:00&nbsp;<BR>
 					13:15</TD>
-				<TD class="item"><font size=-2>CS2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagadejijdwansyntropyadslalcomcoukKk" target=session><b>Dispersed Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PaulDyson&type=bio" target=person>Paul&nbsp;Dyson</a> <i>e2x&nbsp;limited</i></TD>
-				<TD class="item"><font size=-2>TU5</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdabcjdapdjeifcfidiptdialinnetKk" target=session><b>Understanding Project Dynamics</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JensColdewey&type=bio" target=person>Jens&nbsp;Coldewey</a> <i>Coldewey&nbsp;Consulting</i></TD>
+				<TD class="item"><font size=-2>CS2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagadejijdwansyntropyadslalcomcoukKk" target=session><b>Dispersed Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i>, <a href="/cgi-bin/wiki.pl/?browse=PaulDyson&type=bio" target=person>Paul&nbsp;Dyson</a> <i>e2x&nbsp;limited</i></TD>
+				<TD class="item"><font size=-2>TU5</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdabcjdapdjeifcfidiptdialinnetKk" target=session><b>Understanding Project Dynamics</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JensColdewey&type=bio" target=person>Jens&nbsp;Coldewey</a> <i>Coldewey&nbsp;Consulting</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">13:15&nbsp;
 					<BR>
 					14:45</TD>
-				<TD class="break" colSpan="5">Lunch and <A href="http://www.spaconference.org/ot2004/bof.shtml">
+				<TD class="break" colSpan="5">Lunch and <A href="/ot2004/bof.shtml">
 						BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">14:45&nbsp;<BR>
 					16:00</TD>
-				<TD class="item"><font size=-2>WS11</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcebbcfbbcjdfibbgKk" target=session><b>A Picture Paints a Thousand Words - Or does it?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MattStephenson&type=bio" target=person>MattStephenson</a> <i>Royal&nbsp;& SunAlliance</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=StephenHutchinson&type=bio" target=person>StephenHutchinson</a> <i>Royal&nbsp;and Sunalliance</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS12</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaegccchostibbcicaadjinaddrbtopenworldcomKk" target=session><b>Towards EJB 3.0</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=ScottCrawford&type=bio" target=person>Scott&nbsp;Crawford</a> <i>Independent</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>SI1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbafjcdhijbdslcbhbffbhegzencoukKk" target=session><b>Tracer Bullets Reloaded</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PaulSimmons&type=bio" target=person>Paul&nbsp;Simmons</a> <i>Rochester&nbsp;Software House</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobWestgeest&type=bio" target=person>Rob&nbsp;Westgeest</a> <i>Agidem</i></TD>
-				<TD class="item"><font size=-2>WS18</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcbhfdakeithbraithwaitedemoncoukKk" target=session><b>How to Fail at XP</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=SteveFreeman&type=bio" target=person>SteveFreeman</a> <i>Thoughtworks</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i></TD>
-				<TD class="item" rowspan="2"><font size=-2>WS19</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbdeggacbdhibgebfcKk" target=session><b>Soft Systems Methodology - Learning an Approach to Requirements</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DebbieLawther&type=bio" target=person>Debbie&nbsp;Lawther</a> <i>Dover&nbsp;Harbour Board</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobDay&type=bio" target=person>Rob&nbsp;Day</a> <i>RDA&nbsp;Limited</i></TD>
+				<TD class="item"><font size=-2>WS11</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcebbcfbbcjdfibbgKk" target=session><b>A Picture Paints a Thousand Words - Or does it?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MattStephenson&type=bio" target=person>MattStephenson</a> <i>Royal&nbsp;& SunAlliance</i>, <a href="/cgi-bin/wiki.pl/?browse=StephenHutchinson&type=bio" target=person>StephenHutchinson</a> <i>Royal&nbsp;and Sunalliance</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS12</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaegccchostibbcicaadjinaddrbtopenworldcomKk" target=session><b>Towards EJB 3.0</b></a><br><a href="/cgi-bin/wiki.pl/?browse=ScottCrawford&type=bio" target=person>Scott&nbsp;Crawford</a> <i>Independent</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>SI1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbafjcdhijbdslcbhbffbhegzencoukKk" target=session><b>Tracer Bullets Reloaded</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PaulSimmons&type=bio" target=person>Paul&nbsp;Simmons</a> <i>Rochester&nbsp;Software House</i>, <a href="/cgi-bin/wiki.pl/?browse=RobWestgeest&type=bio" target=person>Rob&nbsp;Westgeest</a> <i>Agidem</i></TD>
+				<TD class="item"><font size=-2>WS18</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcbhfdakeithbraithwaitedemoncoukKk" target=session><b>How to Fail at XP</b></a><br><a href="/cgi-bin/wiki.pl/?browse=SteveFreeman&type=bio" target=person>SteveFreeman</a> <i>Thoughtworks</i>, <a href="/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i></TD>
+				<TD class="item" rowspan="2"><font size=-2>WS19</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbdeggacbdhibgebfcKk" target=session><b>Soft Systems Methodology - Learning an Approach to Requirements</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DebbieLawther&type=bio" target=person>Debbie&nbsp;Lawther</a> <i>Dover&nbsp;Harbour Board</i>, <a href="/cgi-bin/wiki.pl/?browse=RobDay&type=bio" target=person>Rob&nbsp;Day</a> <i>RDA&nbsp;Limited</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">16:30&nbsp;<BR>
 					17:45</TD>
-				<TD class="item"><font size=-2>GB1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbefifhdslcbhbffcaagezencoukKk" target=session><b>MDA - this year's silver bullet?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DanHaywood&type=bio" target=person>Dan&nbsp;Haywood</a> <i>Haywood&nbsp;Associates Ltd.</i></TD>
-				<TD class="item"><font size=-2>TT1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagejfjjagdslcbhbffbibcfezencoukKk" target=session><b>Radical Computing</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>PeterMarks</a> <i>Digita</i></TD>
+				<TD class="item"><font size=-2>GB1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbefifhdslcbhbffcaagezencoukKk" target=session><b>MDA - this year's silver bullet?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DanHaywood&type=bio" target=person>Dan&nbsp;Haywood</a> <i>Haywood&nbsp;Associates Ltd.</i></TD>
+				<TD class="item"><font size=-2>TT1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagejfjjagdslcbhbffbibcfezencoukKk" target=session><b>Radical Computing</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>PeterMarks</a> <i>Digita</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">18:15&nbsp;<BR>
@@ -307,7 +307,7 @@
 				<TD class="time">20:45&nbsp;<BR>
 					21:45</TD>
 				<TD class="plenary" colSpan="2">Diversions</TD>
-				<TD class="plenary" colSpan="3"><A href="http://www.spaconference.org/ot2004/bof.shtml">BOF sessions</A></TD>
+				<TD class="plenary" colSpan="3"><A href="/ot2004/bof.shtml">BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">21:45&nbsp;<BR>
@@ -337,22 +337,22 @@
 			<TR vAlign="top">
 				<TD class="time">09:00&nbsp;<BR>
 					10:00</TD>
-				<TD class="plenary" colSpan="5"><font size=-2>PL3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcjbiKk" target=session><b>How to Design a Good API and Why it Matters</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JoshuaBloch&type=bio" target=person>Joshua&nbsp;Bloch</a> <i>Sun&nbsp;Microsystems</i></TD>
+				<TD class="plenary" colSpan="5"><font size=-2>PL3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcjbiKk" target=session><b>How to Design a Good API and Why it Matters</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JoshuaBloch&type=bio" target=person>Joshua&nbsp;Bloch</a> <i>Sun&nbsp;Microsystems</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">10:15&nbsp;<BR>
 					11:30</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS15</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcejhiebhostibbdgcbjhainaddrbtopenworldcomKk" target=session><b>Discovery Made Easy</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BernardHoran&type=bio" target=person>Bernard&nbsp;Horan</a> <i>Sun&nbsp;Microsystems</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=LauraHill&type=bio" target=person>Laura&nbsp;Hill</a> <i>Sun&nbsp;Microsystems</i></TD>
-				<TD class="item"><font size=-2>TT2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcahicdproxybdraegercomKk" target=session><b>Sustainable Architecture</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KlausMarquardt&type=bio" target=person>Klaus&nbsp;Marquardt</a> <i>Dräger&nbsp;Medical AG</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS6</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccgfccbjchgbgciKk" target=session><b>The Software Engineer's View of Content Management</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndreasRping&type=bio" target=person>Andreas&nbsp;Rüping</a> <i>sd&m&nbsp;AG, Hamburg, Germany</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS16</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagegehhgidslcbhbffcaabcbzencoukKk" target=session><b>The Software Value Chain</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DavidHarvey&type=bio" target=person>David&nbsp;Harvey</a> <i>Sibelius&nbsp;Software</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>Peter&nbsp;Marks</a> <i>Digita</i></TD>
-				<TD class="item"><font size=-2>TU7</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcefjhbihostibbfcbcagdrangeibbfcbtcentralpluscomKk" target=session><b>Objects on ACID</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NicholasSimons&type=bio" target=person>Nicholas&nbsp;Simons</a> <i>Metamaxim&nbsp;Ltd.</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS15</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcejhiebhostibbdgcbjhainaddrbtopenworldcomKk" target=session><b>Discovery Made Easy</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BernardHoran&type=bio" target=person>Bernard&nbsp;Horan</a> <i>Sun&nbsp;Microsystems</i>, <a href="/cgi-bin/wiki.pl/?browse=LauraHill&type=bio" target=person>Laura&nbsp;Hill</a> <i>Sun&nbsp;Microsystems</i></TD>
+				<TD class="item"><font size=-2>TT2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcahicdproxybdraegercomKk" target=session><b>Sustainable Architecture</b></a><br><a href="/cgi-bin/wiki.pl/?browse=KlausMarquardt&type=bio" target=person>Klaus&nbsp;Marquardt</a> <i>Dräger&nbsp;Medical AG</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS6</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccgfccbjchgbgciKk" target=session><b>The Software Engineer's View of Content Management</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AndreasRping&type=bio" target=person>Andreas&nbsp;Rüping</a> <i>sd&m&nbsp;AG, Hamburg, Germany</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS16</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagegehhgidslcbhbffcaabcbzencoukKk" target=session><b>The Software Value Chain</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DavidHarvey&type=bio" target=person>David&nbsp;Harvey</a> <i>Sibelius&nbsp;Software</i>, <a href="/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>Peter&nbsp;Marks</a> <i>Digita</i></TD>
+				<TD class="item"><font size=-2>TU7</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcefjhbihostibbfcbcagdrangeibbfcbtcentralpluscomKk" target=session><b>Objects on ACID</b></a><br><a href="/cgi-bin/wiki.pl/?browse=NicholasSimons&type=bio" target=person>Nicholas&nbsp;Simons</a> <i>Metamaxim&nbsp;Ltd.</i></TD>
 			</TR>
 			<TR>
 				<TD class="time">12:00<BR>
 					13:15</TD>
-				<TD class="item"><font size=-2>XX1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndyCarmichael&type=bio" target=person>Andy&nbsp;Carmichael</a> <i>Ivis&nbsp;Technologies LLC</i></TD>
-				<TD class="item"><font size=-2>TU8</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcgjghjccbhcahbhabhiKk" target=session><b>Taming the Tiger: Using Java 1.5</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BenedictHeal&type=bio" target=person>Benedict&nbsp;Heal</a> <i>Fastnloose&nbsp;Ltd</i></TD>
+				<TD class="item"><font size=-2>XX1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AndyCarmichael&type=bio" target=person>Andy&nbsp;Carmichael</a> <i>Ivis&nbsp;Technologies LLC</i></TD>
+				<TD class="item"><font size=-2>TU8</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcgjghjccbhcahbhabhiKk" target=session><b>Taming the Tiger: Using Java 1.5</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BenedictHeal&type=bio" target=person>Benedict&nbsp;Heal</a> <i>Fastnloose&nbsp;Ltd</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">13:15&nbsp;<BR>
@@ -362,10 +362,10 @@
 			<TR vAlign="top">
 				<TD class="time">14:15&nbsp;<BR>
 					15:30</TD>
-				<TD class="item"><font size=-2>TT3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdhchjcgcbdhihibigKk" target=session><b>Component co-ordination in models</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RichardMitchell&type=bio" target=person>Richard&nbsp;Mitchell</a> <i>InferData&nbsp;Corporation</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobJames&type=bio" target=person>Rob&nbsp;James</a> <i>HSBC</i></TD>
-				<TD class="item"><font size=-2>XX1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndyCarmichael&type=bio" target=person>Andy&nbsp;Carmichael</a> <i>Ivis&nbsp;Technologies LLC</i></TD>			
-				<TD class="item"><font size=-2>WS14</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdadeagcpcpabhebbbjpcshowardabmdcomcastnetKk" target=session><b>Blogs and RSS - worth your time?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JamesRobertson&type=bio" target=person>James&nbsp;Robertson</a> <i>Cincom&nbsp;Systems, Inc.</i></TD>
-				<TD class="item"><font size=-2>CS4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbccgfespringbankhudacukKk" target=session><b>The difficulties we encountered in developing an object model to support requirements development.</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=SteveWade&type=bio" target=person>Steve&nbsp;Wade</a> <i>University&nbsp;of Huddersfield</i></TD>
+				<TD class="item"><font size=-2>TT3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdhchjcgcbdhihibigKk" target=session><b>Component co-ordination in models</b></a><br><a href="/cgi-bin/wiki.pl/?browse=RichardMitchell&type=bio" target=person>Richard&nbsp;Mitchell</a> <i>InferData&nbsp;Corporation</i>, <a href="/cgi-bin/wiki.pl/?browse=RobJames&type=bio" target=person>Rob&nbsp;James</a> <i>HSBC</i></TD>
+				<TD class="item"><font size=-2>XX1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AndyCarmichael&type=bio" target=person>Andy&nbsp;Carmichael</a> <i>Ivis&nbsp;Technologies LLC</i></TD>			
+				<TD class="item"><font size=-2>WS14</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdadeagcpcpabhebbbjpcshowardabmdcomcastnetKk" target=session><b>Blogs and RSS - worth your time?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JamesRobertson&type=bio" target=person>James&nbsp;Robertson</a> <i>Cincom&nbsp;Systems, Inc.</i></TD>
+				<TD class="item"><font size=-2>CS4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbccgfespringbankhudacukKk" target=session><b>The difficulties we encountered in developing an object model to support requirements development.</b></a><br><a href="/cgi-bin/wiki.pl/?browse=SteveWade&type=bio" target=person>Steve&nbsp;Wade</a> <i>University&nbsp;of Huddersfield</i></TD>
 				<TD></TD>
 			</TR>
 			<TR vAlign="top">

--- a/ot2004/programme1836.shtml
+++ b/ot2004/programme1836.shtml
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 
-<!-- saved from url=(0044)http://www.spaconference.org/ot2004/programmeTemplate.html -->
+<!-- saved from url=(0044)/ot2004/programmeTemplate.html -->
 <!-- OT Programme Template (magic phrase - - leave this line in) -->
 <HTML>
 <HEAD>
@@ -73,7 +73,7 @@
 					</div>
 				</td>
 				<td>
-					<H4><A href="http://www.spaconference.org/ot2004/"></A>Session Types</H4>
+					<H4><A href="/ot2004/"></A>Session Types</H4>
 						<P>
 							<TABLE id="Table4" border="0">
 								<TR>
@@ -116,9 +116,9 @@
 					</P>
 				</TD>
 	
-				<TD class="item" rowSpan="2"><font size=-2>WG1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaecabhcoproxyfavayacomKk" target=session><b>Seeing the forest and the trees </b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WG3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcabhifgcibaabfcKk" target=session><b>Getting the message?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DavidBell&type=bio" target=person>David&nbsp;Bell</a> <i>MFESD</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WG4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbahdfgchbdKk" target=session><b>Xbots</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DuncanPierce&type=bio" target=person>Duncan&nbsp;Pierce</a> <i>Amarinda</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WG1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaecabhcoproxyfavayacomKk" target=session><b>Seeing the forest and the trees </b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WG3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcabhifgcibaabfcKk" target=session><b>Getting the message?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DavidBell&type=bio" target=person>David&nbsp;Bell</a> <i>MFESD</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WG4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbahdfgchbdKk" target=session><b>Xbots</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DuncanPierce&type=bio" target=person>Duncan&nbsp;Pierce</a> <i>Amarinda</i></TD>
 				<TD rowSpan="1"></TD>
 				<TD rowSpan="2"></TD>
 			</TR>
@@ -129,14 +129,14 @@
 					</P>
 				</TD>
 	
-				<TD class="item" rowSpan="1"><font size=-2>TU11</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbahdfgcjfdKk" target=session><b>UML 1++</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i>ThoughtWorks</i></TD>
+				<TD class="item" rowSpan="1"><font size=-2>TU11</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbahdfgcjfdKk" target=session><b>UML 1++</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i>ThoughtWorks</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">
 					<P>19:30<BR>
 						22:00</P>
 				</TD>
-				<TD class="break" colSpan="5">Reception with buffet sponsored by <A href="http://www.spaconference.org/cgi-bin/wiki.pl/?ThoughtWorks">
+				<TD class="break" colSpan="5">Reception with buffet sponsored by <A href="/cgi-bin/wiki.pl/?ThoughtWorks">
 						ThoughtWorks</A></TD>
 			</TR>
 			<TR vAlign="top">
@@ -168,17 +168,17 @@
 			<TR vAlign="top">
 				<TD class="time">09:45<BR>
 					11:00</TD>
-				<TD class="item" rowSpan="2"><font size=-2>TU1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbicbebhainbhexamscomKk" target=session><b>Getting to Grips with Architecture Using Viewpoints and Perspectives</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NickRozanski&type=bio" target=person>Nick&nbsp;Rozanski</a> <i>French&nbsp;Thornton</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagbjhfiejevispcacheabopsasmrabenergisidcnetKk" target=session><b>Delegation in Java</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=ErikGroeneveld&type=bio" target=person>Erik&nbsp;Groeneveld</a> <i>Seek&nbsp;You Too B.V.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=WillemvandenEnde&type=bio" target=person>Willem&nbsp;van&nbsp;den&nbsp;Ende</a> <i>CQ2</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbafheacijchostcbhdjjjjinaddrbtopenworldcomKk" target=session><b>How to Win Friends and Influence People</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NigelGilkes&type=bio" target=person>Nigel&nbsp;Gilkes</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
-				<TD class="item"><font size=-2>WS13</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifdgefKk" target=session><b>Personality Traits: Do I have any?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JaneChandler&type=bio" target=person>Jane&nbsp;Chandler</a> <i>University&nbsp;of Portsmouth</i></TD>
-				<TD class="item"><font size=-2>TU10</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcjjeKk" target=session><b>Mock Objects: Driving top-down development.</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JoeWalnes&type=bio" target=person>Joe&nbsp;Walnes</a> <i>ThoughtWorks</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NatPryce&type=bio" target=person>Nat&nbsp;Pryce</a> <i>B13media&nbsp;Ltd.</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>TU1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbicbebhainbhexamscomKk" target=session><b>Getting to Grips with Architecture Using Viewpoints and Perspectives</b></a><br><a href="/cgi-bin/wiki.pl/?browse=NickRozanski&type=bio" target=person>Nick&nbsp;Rozanski</a> <i>French&nbsp;Thornton</i>, <a href="/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagbjhfiejevispcacheabopsasmrabenergisidcnetKk" target=session><b>Delegation in Java</b></a><br><a href="/cgi-bin/wiki.pl/?browse=ErikGroeneveld&type=bio" target=person>Erik&nbsp;Groeneveld</a> <i>Seek&nbsp;You Too B.V.</i>, <a href="/cgi-bin/wiki.pl/?browse=WillemvandenEnde&type=bio" target=person>Willem&nbsp;van&nbsp;den&nbsp;Ende</a> <i>CQ2</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbafheacijchostcbhdjjjjinaddrbtopenworldcomKk" target=session><b>How to Win Friends and Influence People</b></a><br><a href="/cgi-bin/wiki.pl/?browse=NigelGilkes&type=bio" target=person>Nigel&nbsp;Gilkes</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
+				<TD class="item"><font size=-2>WS13</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifdgefKk" target=session><b>Personality Traits: Do I have any?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JaneChandler&type=bio" target=person>Jane&nbsp;Chandler</a> <i>University&nbsp;of Portsmouth</i></TD>
+				<TD class="item"><font size=-2>TU10</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcjjeKk" target=session><b>Mock Objects: Driving top-down development.</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JoeWalnes&type=bio" target=person>Joe&nbsp;Walnes</a> <i>ThoughtWorks</i>, <a href="/cgi-bin/wiki.pl/?browse=NatPryce&type=bio" target=person>Nat&nbsp;Pryce</a> <i>B13media&nbsp;Ltd.</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">11:30<BR>
 					12:45</TD>
-				<TD class="item"><font size=-2>CS1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcedbbbhostibbciceibbhinaddrbtopenworldcomKk" target=session><b>The Compute Backbone at JPMorgan</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterSumner&type=bio" target=person>Peter&nbsp;Sumner</a> <i>JPMorgan</i></TD>
-				<TD class="item"><font size=-2>TU9</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcegfKk" target=session><b>The Application Reference Model</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnCheesman&type=bio" target=person>John&nbsp;Cheesman</a> <i>7irene</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=GregHodgkinson&type=bio" target=person>Greg&nbsp;Hodgkinson</a> <i>7irene</i></TD>
+				<TD class="item"><font size=-2>CS1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcedbbbhostibbciceibbhinaddrbtopenworldcomKk" target=session><b>The Compute Backbone at JPMorgan</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PeterSumner&type=bio" target=person>Peter&nbsp;Sumner</a> <i>JPMorgan</i></TD>
+				<TD class="item"><font size=-2>TU9</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcegfKk" target=session><b>The Application Reference Model</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnCheesman&type=bio" target=person>John&nbsp;Cheesman</a> <i>7irene</i>, <a href="/cgi-bin/wiki.pl/?browse=GregHodgkinson&type=bio" target=person>Greg&nbsp;Hodgkinson</a> <i>7irene</i></TD>
 			<TR vAlign="top">
 				<TD class="time">12:45&nbsp;<BR>
 					13:45</TD>
@@ -187,11 +187,11 @@
 			<TR vAlign="top">
 				<TD class="time">13:45<BR>
 					15:00</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccgajdkeithbraithwaitedemoncoukKk" target=session><b>How I learned to stop worrying and love metrics</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>IvanMoore</a> <i>ThoughtWorks</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdicfcafhostibbdebhdjfinaddrbtopenworldcomKk" target=session><b>Generic Mechanisms in Software Engineering</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=SimonDavies&type=bio" target=person>Simon&nbsp;Davies</a> <i>Microsoft</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS5</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdadfhhecoproxyfavayacomKk" target=session><b>Systems archetypes -- diagnosing system issues and designing high-leverage interventions</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>CS3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbahecibdibaebfcgcKk" target=session><b>Data distribution in a diverse community</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IanCornwell&type=bio" target=person>Ian&nbsp;Cornwell</a> <i>Mott&nbsp;MacDonald</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS7</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbcahedgccdccdhaKk" target=session><b>Mind the culture gap!</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AliaCooper&type=bio" target=person>Alia&nbsp;Cooper</a> <i>Tesco</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=HelenSharp&type=bio" target=person>Helen&nbsp;Sharp</a> <i>The&nbsp;Open University</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccgajdkeithbraithwaitedemoncoukKk" target=session><b>How I learned to stop worrying and love metrics</b></a><br><a href="/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i>, <a href="/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>IvanMoore</a> <i>ThoughtWorks</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdicfcafhostibbdebhdjfinaddrbtopenworldcomKk" target=session><b>Generic Mechanisms in Software Engineering</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="/cgi-bin/wiki.pl/?browse=SimonDavies&type=bio" target=person>Simon&nbsp;Davies</a> <i>Microsoft</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS5</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdadfhhecoproxyfavayacomKk" target=session><b>Systems archetypes -- diagnosing system issues and designing high-leverage interventions</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartineDevos&type=bio" target=person>Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="/cgi-bin/wiki.pl/?browse=DianeGibson&type=bio" target=person>Diane&nbsp;Gibson</a> <i></i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>CS3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbahecibdibaebfcgcKk" target=session><b>Data distribution in a diverse community</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IanCornwell&type=bio" target=person>Ian&nbsp;Cornwell</a> <i>Mott&nbsp;MacDonald</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS7</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbcahedgccdccdhaKk" target=session><b>Mind the culture gap!</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AliaCooper&type=bio" target=person>Alia&nbsp;Cooper</a> <i>Tesco</i>, <a href="/cgi-bin/wiki.pl/?browse=HelenSharp&type=bio" target=person>Helen&nbsp;Sharp</a> <i>The&nbsp;Open University</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">15:30&nbsp;<BR>
@@ -207,7 +207,7 @@
 			<TR>
 				<TD class="time" height="34">18:15<BR>
 					19:15</TD>
-				<TD class="break" colSpan="5" height="36"><font size=-2>PL1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifbijaKk" target=session><b>An Evening with Ivar Jacobson</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvarJacobson&type=bio" target=person>Ivar&nbsp;Jacobson</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i><A href="http://www.spaconference.org/ot2004/IvarSession.html"></A></TD>
+				<TD class="break" colSpan="5" height="36"><font size=-2>PL1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifbijaKk" target=session><b>An Evening with Ivar Jacobson</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IvarJacobson&type=bio" target=person>Ivar&nbsp;Jacobson</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=BruceAnderson&type=bio" target=person>Bruce&nbsp;Anderson</a> <i>IBM&nbsp;Component Technology Services</i>, <a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i><A href="/ot2004/IvarSession.html"></A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">19:15<BR>
@@ -218,14 +218,14 @@
 				<TD class="time">20:45&nbsp;
 					<BR>
 					21:45</TD>
-				<TD class="plenary" colSpan="5"><font size=-2>XX2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifdccdKk" target=session><b>DynaBoF</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i></TD>
+				<TD class="plenary" colSpan="5"><font size=-2>XX2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifdccdKk" target=session><b>DynaBoF</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">21:45&nbsp;
 					<BR>
 					22:45</TD>
 				<TD class="plenary" colSpan="2">Diversions</TD>
-				<TD class="plenary" colSpan="3"><A href="http://www.spaconference.org/ot2004/bof.shtml">BOF sessions</A></TD>
+				<TD class="plenary" colSpan="3"><A href="/ot2004/bof.shtml">BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time"></TD>
@@ -254,44 +254,44 @@
 				<TD class="time">09:00&nbsp;<BR>
 					10:00</TD>
 				<TD class="plenary" colSpan="5">
-					<P align="left"><font size=-2>PL2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifbehhKk" target=session><b>Software Design in the Twenty-first Century</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i>ThoughtWorks</i></P>
+					<P align="left"><font size=-2>PL2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifbehhKk" target=session><b>Software Design in the Twenty-first Century</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MartinFowler&type=bio" target=person>Martin&nbsp;Fowler</a> <i>ThoughtWorks</i></P>
 				</TD>
 			<TR vAlign="top">
 				<TD class="time">10:15&nbsp;<BR>
 					11:30</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS8</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccfbejcacheglutnserverntlinetKk" target=session><b>What went wrong? Error handling in a distributed environment</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndyLongshaw&type=bio" target=person>Andy&nbsp;Longshaw</a> <i>Blue&nbsp;Skyline</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS9</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcbfghctidebdgmicrosoftcomKk" target=session><b>Domain Specific Languages - issues and exercises</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
-				<TD class="item"><font size=-2>WS10</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcjefecbibfbhdceeKk" target=session><b>Belbin Team Roles in Software Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DuncanMcGregor&type=bio" target=person>Duncan&nbsp;McGregor</a> <i></i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RichardCare&type=bio" target=person>Richard&nbsp;Care</a> <i>Octave&nbsp;Associates</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>TU3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagbffdghhcbcbfijfcbaKk" target=session><b>Test Driven Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>Ivan&nbsp;Moore</a> <i>ThoughtWorks</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DuncanPierce&type=bio" target=person>Duncan&nbsp;Pierce</a> <i>Amarinda</i></TD>
-				<TD class="item"><font size=-2>TU4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdfdbacbdialgcgeccadfaccessuktiscalicomKk" target=session><b>Getting Your Story Straight</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RachelDavies&type=bio" target=person>Rachel&nbsp;Davies</a> <i>Agile&nbsp;Experience</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS8</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccfbejcacheglutnserverntlinetKk" target=session><b>What went wrong? Error handling in a distributed environment</b></a><br><a href="/cgi-bin/wiki.pl/?browse=EoinWoods&type=bio" target=person>Eoin&nbsp;Woods</a> <i>Artechra&nbsp;Limited</i>, <a href="/cgi-bin/wiki.pl/?browse=AndyLongshaw&type=bio" target=person>Andy&nbsp;Longshaw</a> <i>Blue&nbsp;Skyline</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS9</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcbfghctidebdgmicrosoftcomKk" target=session><b>Domain Specific Languages - issues and exercises</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AlanCameronWills&type=bio" target=person>Alan&nbsp;Cameron&nbsp;Wills</a> <i>Microsoft</i></TD>
+				<TD class="item"><font size=-2>WS10</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcjefecbibfbhdceeKk" target=session><b>Belbin Team Roles in Software Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DuncanMcGregor&type=bio" target=person>Duncan&nbsp;McGregor</a> <i></i>, <a href="/cgi-bin/wiki.pl/?browse=RichardCare&type=bio" target=person>Richard&nbsp;Care</a> <i>Octave&nbsp;Associates</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>TU3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagbffdghhcbcbfijfcbaKk" target=session><b>Test Driven Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=IvanMoore&type=bio" target=person>Ivan&nbsp;Moore</a> <i>ThoughtWorks</i>, <a href="/cgi-bin/wiki.pl/?browse=DuncanPierce&type=bio" target=person>Duncan&nbsp;Pierce</a> <i>Amarinda</i></TD>
+				<TD class="item"><font size=-2>TU4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdfdbacbdialgcgeccadfaccessuktiscalicomKk" target=session><b>Getting Your Story Straight</b></a><br><a href="/cgi-bin/wiki.pl/?browse=RachelDavies&type=bio" target=person>Rachel&nbsp;Davies</a> <i>Agile&nbsp;Experience</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">12:00&nbsp;<BR>
 					13:15</TD>
-				<TD class="item"><font size=-2>CS2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagadejijdwansyntropyadslalcomcoukKk" target=session><b>Dispersed Development</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PaulDyson&type=bio" target=person>Paul&nbsp;Dyson</a> <i>e2x&nbsp;limited</i></TD>
-				<TD class="item"><font size=-2>TU5</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdabcjdapdjeifcfidiptdialinnetKk" target=session><b>Understanding Project Dynamics</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JensColdewey&type=bio" target=person>Jens&nbsp;Coldewey</a> <i>Coldewey&nbsp;Consulting</i></TD>
+				<TD class="item"><font size=-2>CS2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagadejijdwansyntropyadslalcomcoukKk" target=session><b>Dispersed Development</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JohnDaniels&type=bio" target=person>John&nbsp;Daniels</a> <i>Syntropy&nbsp;Limited</i>, <a href="/cgi-bin/wiki.pl/?browse=PaulDyson&type=bio" target=person>Paul&nbsp;Dyson</a> <i>e2x&nbsp;limited</i></TD>
+				<TD class="item"><font size=-2>TU5</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdabcjdapdjeifcfidiptdialinnetKk" target=session><b>Understanding Project Dynamics</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JensColdewey&type=bio" target=person>Jens&nbsp;Coldewey</a> <i>Coldewey&nbsp;Consulting</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">13:15&nbsp;
 					<BR>
 					14:45</TD>
-				<TD class="break" colSpan="5">Lunch and <A href="http://www.spaconference.org/ot2004/bof.shtml">
+				<TD class="break" colSpan="5">Lunch and <A href="/ot2004/bof.shtml">
 						BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">14:45&nbsp;<BR>
 					16:00</TD>
-				<TD class="item"><font size=-2>WS11</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcebbcfbbcjdfibbgKk" target=session><b>A Picture Paints a Thousand Words - Or does it?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MattStephenson&type=bio" target=person>MattStephenson</a> <i>Royal&nbsp;& SunAlliance</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=StephenHutchinson&type=bio" target=person>StephenHutchinson</a> <i>Royal&nbsp;and Sunalliance</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS12</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaegccchostibbcicaadjinaddrbtopenworldcomKk" target=session><b>Towards EJB 3.0</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=ScottCrawford&type=bio" target=person>Scott&nbsp;Crawford</a> <i>Independent</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>SI1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbafjcdhijbdslcbhbffbhegzencoukKk" target=session><b>Tracer Bullets Reloaded</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PaulSimmons&type=bio" target=person>Paul&nbsp;Simmons</a> <i>Rochester&nbsp;Software House</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobWestgeest&type=bio" target=person>Rob&nbsp;Westgeest</a> <i>Agidem</i></TD>
-				<TD class="item"><font size=-2>WS18</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcbhfdakeithbraithwaitedemoncoukKk" target=session><b>How to Fail at XP</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=SteveFreeman&type=bio" target=person>SteveFreeman</a> <i>Thoughtworks</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i></TD>
-				<TD class="item" rowspan="2"><font size=-2>WS19</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbdeggacbdhibgebfcKk" target=session><b>Soft Systems Methodology - Learning an Approach to Requirements</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DebbieLawther&type=bio" target=person>Debbie&nbsp;Lawther</a> <i>Dover&nbsp;Harbour Board</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobDay&type=bio" target=person>Rob&nbsp;Day</a> <i>RDA&nbsp;Limited</i></TD>
+				<TD class="item"><font size=-2>WS11</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcebbcfbbcjdfibbgKk" target=session><b>A Picture Paints a Thousand Words - Or does it?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=MattStephenson&type=bio" target=person>MattStephenson</a> <i>Royal&nbsp;& SunAlliance</i>, <a href="/cgi-bin/wiki.pl/?browse=StephenHutchinson&type=bio" target=person>StephenHutchinson</a> <i>Royal&nbsp;and Sunalliance</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS12</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaegccchostibbcicaadjinaddrbtopenworldcomKk" target=session><b>Towards EJB 3.0</b></a><br><a href="/cgi-bin/wiki.pl/?browse=ScottCrawford&type=bio" target=person>Scott&nbsp;Crawford</a> <i>Independent</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>SI1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbafjcdhijbdslcbhbffbhegzencoukKk" target=session><b>Tracer Bullets Reloaded</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PaulSimmons&type=bio" target=person>Paul&nbsp;Simmons</a> <i>Rochester&nbsp;Software House</i>, <a href="/cgi-bin/wiki.pl/?browse=RobWestgeest&type=bio" target=person>Rob&nbsp;Westgeest</a> <i>Agidem</i></TD>
+				<TD class="item"><font size=-2>WS18</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcbhfdakeithbraithwaitedemoncoukKk" target=session><b>How to Fail at XP</b></a><br><a href="/cgi-bin/wiki.pl/?browse=SteveFreeman&type=bio" target=person>SteveFreeman</a> <i>Thoughtworks</i>, <a href="/cgi-bin/wiki.pl/?browse=KeithBraithwaite&type=bio" target=person>KeithBraithwaite</a> <i>Penrillian</i></TD>
+				<TD class="item" rowspan="2"><font size=-2>WS19</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbdeggacbdhibgebfcKk" target=session><b>Soft Systems Methodology - Learning an Approach to Requirements</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DebbieLawther&type=bio" target=person>Debbie&nbsp;Lawther</a> <i>Dover&nbsp;Harbour Board</i>, <a href="/cgi-bin/wiki.pl/?browse=RobDay&type=bio" target=person>Rob&nbsp;Day</a> <i>RDA&nbsp;Limited</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">16:30&nbsp;<BR>
 					17:45</TD>
-				<TD class="item"><font size=-2>GB1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbefifhdslcbhbffcaagezencoukKk" target=session><b>MDA - this year's silver bullet?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DanHaywood&type=bio" target=person>Dan&nbsp;Haywood</a> <i>Haywood&nbsp;Associates Ltd.</i></TD>
-				<TD class="item"><font size=-2>TT1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagejfjjagdslcbhbffbibcfezencoukKk" target=session><b>Radical Computing</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>PeterMarks</a> <i>Digita</i></TD>
+				<TD class="item"><font size=-2>GB1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbefifhdslcbhbffcaagezencoukKk" target=session><b>MDA - this year's silver bullet?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DanHaywood&type=bio" target=person>Dan&nbsp;Haywood</a> <i>Haywood&nbsp;Associates Ltd.</i></TD>
+				<TD class="item"><font size=-2>TT1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagejfjjagdslcbhbffbibcfezencoukKk" target=session><b>Radical Computing</b></a><br><a href="/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>PeterMarks</a> <i>Digita</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">18:15&nbsp;<BR>
@@ -307,7 +307,7 @@
 				<TD class="time">20:45&nbsp;<BR>
 					21:45</TD>
 				<TD class="plenary" colSpan="2">Diversions</TD>
-				<TD class="plenary" colSpan="3"><A href="http://www.spaconference.org/ot2004/bof.shtml">BOF sessions</A></TD>
+				<TD class="plenary" colSpan="3"><A href="/ot2004/bof.shtml">BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">21:45&nbsp;<BR>
@@ -337,22 +337,22 @@
 			<TR vAlign="top">
 				<TD class="time">09:00&nbsp;<BR>
 					10:00</TD>
-				<TD class="plenary" colSpan="5"><font size=-2>PL3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbaghifcjbiKk" target=session><b>How to Design a Good API and Why it Matters</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JoshuaBloch&type=bio" target=person>Joshua&nbsp;Bloch</a> <i>Sun&nbsp;Microsystems</i></TD>
+				<TD class="plenary" colSpan="5"><font size=-2>PL3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbaghifcjbiKk" target=session><b>How to Design a Good API and Why it Matters</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JoshuaBloch&type=bio" target=person>Joshua&nbsp;Bloch</a> <i>Sun&nbsp;Microsystems</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">10:15&nbsp;<BR>
 					11:30</TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS15</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcejhiebhostibbdgcbjhainaddrbtopenworldcomKk" target=session><b>Discovery Made Easy</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BernardHoran&type=bio" target=person>Bernard&nbsp;Horan</a> <i>Sun&nbsp;Microsystems</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=LauraHill&type=bio" target=person>Laura&nbsp;Hill</a> <i>Sun&nbsp;Microsystems</i></TD>
-				<TD class="item"><font size=-2>TT2</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcahicdproxybdraegercomKk" target=session><b>Sustainable Architecture</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=KlausMarquardt&type=bio" target=person>Klaus&nbsp;Marquardt</a> <i>Dräger&nbsp;Medical AG</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS6</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdccgfccbjchgbgciKk" target=session><b>The Software Engineer's View of Content Management</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndreasRping&type=bio" target=person>Andreas&nbsp;Rüping</a> <i>sd&m&nbsp;AG, Hamburg, Germany</i></TD>
-				<TD class="item" rowSpan="2"><font size=-2>WS16</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagegehhgidslcbhbffcaabcbzencoukKk" target=session><b>The Software Value Chain</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DavidHarvey&type=bio" target=person>David&nbsp;Harvey</a> <i>Sibelius&nbsp;Software</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>Peter&nbsp;Marks</a> <i>Digita</i></TD>
-				<TD class="item"><font size=-2>TU7</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcefjhbihostibbfcbcagdrangeibbfcbtcentralpluscomKk" target=session><b>Objects on ACID</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=NicholasSimons&type=bio" target=person>Nicholas&nbsp;Simons</a> <i>Metamaxim&nbsp;Ltd.</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS15</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcejhiebhostibbdgcbjhainaddrbtopenworldcomKk" target=session><b>Discovery Made Easy</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BernardHoran&type=bio" target=person>Bernard&nbsp;Horan</a> <i>Sun&nbsp;Microsystems</i>, <a href="/cgi-bin/wiki.pl/?browse=LauraHill&type=bio" target=person>Laura&nbsp;Hill</a> <i>Sun&nbsp;Microsystems</i></TD>
+				<TD class="item"><font size=-2>TT2</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcahicdproxybdraegercomKk" target=session><b>Sustainable Architecture</b></a><br><a href="/cgi-bin/wiki.pl/?browse=KlausMarquardt&type=bio" target=person>Klaus&nbsp;Marquardt</a> <i>Dräger&nbsp;Medical AG</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS6</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdccgfccbjchgbgciKk" target=session><b>The Software Engineer's View of Content Management</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AndreasRping&type=bio" target=person>Andreas&nbsp;Rüping</a> <i>sd&m&nbsp;AG, Hamburg, Germany</i></TD>
+				<TD class="item" rowSpan="2"><font size=-2>WS16</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagegehhgidslcbhbffcaabcbzencoukKk" target=session><b>The Software Value Chain</b></a><br><a href="/cgi-bin/wiki.pl/?browse=DavidHarvey&type=bio" target=person>David&nbsp;Harvey</a> <i>Sibelius&nbsp;Software</i>, <a href="/cgi-bin/wiki.pl/?browse=PeterMarks&type=bio" target=person>Peter&nbsp;Marks</a> <i>Digita</i></TD>
+				<TD class="item"><font size=-2>TU7</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcefjhbihostibbfcbcagdrangeibbfcbtcentralpluscomKk" target=session><b>Objects on ACID</b></a><br><a href="/cgi-bin/wiki.pl/?browse=NicholasSimons&type=bio" target=person>Nicholas&nbsp;Simons</a> <i>Metamaxim&nbsp;Ltd.</i></TD>
 			</TR>
 			<TR>
 				<TD class="time">12:00<BR>
 					13:15</TD>
-				<TD class="item"><font size=-2>XX1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndyCarmichael&type=bio" target=person>Andy&nbsp;Carmichael</a> <i>Ivis&nbsp;Technologies LLC</i></TD>
-				<TD class="item"><font size=-2>TU8</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcgjghjccbhcahbhabhiKk" target=session><b>Taming the Tiger: Using Java 1.5</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=BenedictHeal&type=bio" target=person>Benedict&nbsp;Heal</a> <i>Fastnloose&nbsp;Ltd</i></TD>
+				<TD class="item"><font size=-2>XX1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AndyCarmichael&type=bio" target=person>Andy&nbsp;Carmichael</a> <i>Ivis&nbsp;Technologies LLC</i></TD>
+				<TD class="item"><font size=-2>TU8</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcgjghjccbhcahbhabhiKk" target=session><b>Taming the Tiger: Using Java 1.5</b></a><br><a href="/cgi-bin/wiki.pl/?browse=BenedictHeal&type=bio" target=person>Benedict&nbsp;Heal</a> <i>Fastnloose&nbsp;Ltd</i></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">13:15&nbsp;<BR>
@@ -362,10 +362,10 @@
 			<TR vAlign="top">
 				<TD class="time">14:15&nbsp;<BR>
 					15:30</TD>
-				<TD class="item"><font size=-2>TT3</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdhchjcgcbdhihibigKk" target=session><b>Component co-ordination in models</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RichardMitchell&type=bio" target=person>Richard&nbsp;Mitchell</a> <i>InferData&nbsp;Corporation</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=RobJames&type=bio" target=person>Rob&nbsp;James</a> <i>HSBC</i></TD>
-				<TD class="item"><font size=-2>XX1</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=AndyCarmichael&type=bio" target=person>Andy&nbsp;Carmichael</a> <i>Ivis&nbsp;Technologies LLC</i></TD>			
-				<TD class="item"><font size=-2>WS14</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdadeagcpcpabhebbbjpcshowardabmdcomcastnetKk" target=session><b>Blogs and RSS - worth your time?</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=JamesRobertson&type=bio" target=person>James&nbsp;Robertson</a> <i>Cincom&nbsp;Systems, Inc.</i></TD>
-				<TD class="item"><font size=-2>CS4</font><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdbccgfespringbankhudacukKk" target=session><b>The difficulties we encountered in developing an object model to support requirements development.</b></a><br><a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=SteveWade&type=bio" target=person>Steve&nbsp;Wade</a> <i>University&nbsp;of Huddersfield</i></TD>
+				<TD class="item"><font size=-2>TT3</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdhchjcgcbdhihibigKk" target=session><b>Component co-ordination in models</b></a><br><a href="/cgi-bin/wiki.pl/?browse=RichardMitchell&type=bio" target=person>Richard&nbsp;Mitchell</a> <i>InferData&nbsp;Corporation</i>, <a href="/cgi-bin/wiki.pl/?browse=RobJames&type=bio" target=person>Rob&nbsp;James</a> <i>HSBC</i></TD>
+				<TD class="item"><font size=-2>XX1</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagcjgjgjeuserdecdfdslpipexcomKk" target=session><b>Famous for Fifteen Minutes</b></a><br><a href="/cgi-bin/wiki.pl/?browse=AndyCarmichael&type=bio" target=person>Andy&nbsp;Carmichael</a> <i>Ivis&nbsp;Technologies LLC</i></TD>			
+				<TD class="item"><font size=-2>WS14</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdadeagcpcpabhebbbjpcshowardabmdcomcastnetKk" target=session><b>Blogs and RSS - worth your time?</b></a><br><a href="/cgi-bin/wiki.pl/?browse=JamesRobertson&type=bio" target=person>James&nbsp;Robertson</a> <i>Cincom&nbsp;Systems, Inc.</i></TD>
+				<TD class="item"><font size=-2>CS4</font><br><a href="/cgi-bin/wiki.pl/ot2004/?KkbagdbccgfespringbankhudacukKk" target=session><b>The difficulties we encountered in developing an object model to support requirements development.</b></a><br><a href="/cgi-bin/wiki.pl/?browse=SteveWade&type=bio" target=person>Steve&nbsp;Wade</a> <i>University&nbsp;of Huddersfield</i></TD>
 				<TD></TD>
 			</TR>
 			<TR vAlign="top">

--- a/ot2004/programmeTemplate.html
+++ b/ot2004/programmeTemplate.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 
-<!-- saved from url=(0044)http://www.spaconference.org/ot2004/programmeTemplate.html -->
+<!-- saved from url=(0044)/ot2004/programmeTemplate.html -->
 <!-- OT Programme Template (magic phrase - - leave this line in) -->
 <HTML>
 <HEAD>
@@ -73,7 +73,7 @@
 					</div>
 				</td>
 				<td>
-					<H4><A href="http://www.spaconference.org/ot2004/"></A>Session Types</H4>
+					<H4><A href="/ot2004/"></A>Session Types</H4>
 						<P>
 							<TABLE id="Table4" border="0">
 								<TR>
@@ -136,7 +136,7 @@
 					<P>19:30<BR>
 						22:00</P>
 				</TD>
-				<TD class="break" colSpan="5">Reception with buffet sponsored by <A href="http://www.spaconference.org/cgi-bin/wiki.pl/?ThoughtWorks">
+				<TD class="break" colSpan="5">Reception with buffet sponsored by <A href="/cgi-bin/wiki.pl/?ThoughtWorks">
 						ThoughtWorks</A></TD>
 			</TR>
 			<TR vAlign="top">
@@ -207,7 +207,7 @@
 			<TR>
 				<TD class="time" height="34">18:15<BR>
 					19:15</TD>
-				<TD class="break" colSpan="5" height="36">#84<A href="http://www.spaconference.org/ot2004/IvarSession.html"></A></TD>
+				<TD class="break" colSpan="5" height="36">#84<A href="/ot2004/IvarSession.html"></A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">19:15<BR>
@@ -225,7 +225,7 @@
 					<BR>
 					22:45</TD>
 				<TD class="plenary" colSpan="2">Diversions</TD>
-				<TD class="plenary" colSpan="3"><A href="http://www.spaconference.org/ot2004/bof.shtml">BOF sessions</A></TD>
+				<TD class="plenary" colSpan="3"><A href="/ot2004/bof.shtml">BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time"></TD>
@@ -275,7 +275,7 @@
 				<TD class="time">13:15&nbsp;
 					<BR>
 					14:45</TD>
-				<TD class="break" colSpan="5">Lunch and <A href="http://www.spaconference.org/ot2004/bof.shtml">
+				<TD class="break" colSpan="5">Lunch and <A href="/ot2004/bof.shtml">
 						BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
@@ -307,7 +307,7 @@
 				<TD class="time">20:45&nbsp;<BR>
 					21:45</TD>
 				<TD class="plenary" colSpan="2">Diversions</TD>
-				<TD class="plenary" colSpan="3"><A href="http://www.spaconference.org/ot2004/bof.shtml">BOF sessions</A></TD>
+				<TD class="plenary" colSpan="3"><A href="/ot2004/bof.shtml">BOF sessions</A></TD>
 			</TR>
 			<TR vAlign="top">
 				<TD class="time">21:45&nbsp;<BR>

--- a/ot2004/register.js
+++ b/ot2004/register.js
@@ -24,7 +24,7 @@ function validateForm() {
 		}
 		// Modified by DMC to block certain countries.
 		if (isBlockedCountry(form.country.value)) {
-			window.location="http://www.spaconference.org/ot2004/registrationoffline.shtml";
+			window.location="/ot2004/registrationoffline.shtml";
 			return;
 		}
 		form.submit();
@@ -55,7 +55,7 @@ function validateDiscountForm() {
 		}
 		// Modified by DMC to block certain countries.
 		if (isBlockedCountry(form.country.value)) {
-			window.location="http://www.spaconference.org/ot2004/registrationoffline.shtml";
+			window.location="/ot2004/registrationoffline.shtml";
 			return;
 		}
 		form.submit();
@@ -86,7 +86,7 @@ function validateComplementaryForm() {
 //		}
 		// Modified by DMC to block certain countries.
 		if (isBlockedCountry(form.country.value)) {
-			window.location="http://www.spaconference.org/ot2004/registrationoffline.shtml";
+			window.location="/ot2004/registrationoffline.shtml";
 			return;
 		}
 		form.submit();

--- a/ot2004/selectSunday.html
+++ b/ot2004/selectSunday.html
@@ -2,7 +2,7 @@
 	xmlns:w="urn:schemas-microsoft-com:office:word" xmlns="http://www.w3.org/TR/REC-html40">
 	<HEAD>
 		<title>OT2004 - Programme</title> 
-		<!-- saved from url=(0044)http://www.spaconference.org/ot2004/programmeTemplate.html -->
+		<!-- saved from url=(0044)/ot2004/programmeTemplate.html -->
 		<!-- OT Programme Template (magic phrase - - leave this line in) -->
 		<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
 		<meta name="ProgId" content="Word.Document">
@@ -46,7 +46,7 @@ w\:* {behavior:url(#default#VML);}
  <w:LatentStyles DefLockedState="false" LatentStyleCount="156">
  </w:LatentStyles>
 </xml><![endif]-->
-				<link rel="Stylesheet" type="text/css" media="all" href="http://www.spaconference.org/ot2004/ot.css">
+				<link rel="Stylesheet" type="text/css" media="all" href="/ot2004/ot.css">
 					<style> <!-- border: windowtext 1px solid; padding: 2px; font: normal 11px arial,sans-serif; color: black; white-space: normal; text-decoration: none; .break, plenary, time { vertical-align: bottom }
 	/* Font Definitions */ @font-face {font-family:Verdana; panose-1:2 11 6 4 3 5 4 4 2 4; mso-font-charset:0; mso-generic-font-family:swiss; mso-font-pitch:variable; mso-font-signature:536871559 0 0 0 415 0;}
 	/* Style Definitions */ p.MsoNormal, li.MsoNormal, div.MsoNormal {mso-style-parent:""; margin:0cm; margin-bottom:.0001pt; text-align:left; mso-pagination:widow-orphan; font-size:12.0pt; font-family:"Times New Roman"; mso-fareast-font-family:"Times New Roman";}
@@ -110,7 +110,7 @@ w\:* {behavior:url(#default#VML);}
 		<div class="Section1">
 		<table><tr><td class="MsoNormal" style='BACKGROUND:#0f228c'>
 					<p class="MsoNormal" style='BACKGROUND:#0f228c'><span style='FONT-SIZE:13.5pt;
-FONT-FAMILY:Verdana'><a href="http://www.spaconference.org/ot2004/index.shtml"><span style='TEXT-DECORATION:none;text-underline:none'><img border="0" width="169" height="115" id="_x0000_i1025" src="http://www.spaconference.org/ot2004/images/otlogo.gif"
+FONT-FAMILY:Verdana'><a href="/ot2004/index.shtml"><span style='TEXT-DECORATION:none;text-underline:none'><img border="0" width="169" height="115" id="_x0000_i1025" src="/ot2004/images/otlogo.gif"
 										alt="OT2004"></span></a><o:p></o:p>
 						</span></p>
 					<div><!-- the two statements on the previous line musn't have any space between them -->
@@ -119,42 +119,42 @@ Software Practice<o:p></o:p></span></b></p>
 					</div>
 					<div style='MARGIN-LEFT:7.5pt'>
 						<p class="MsoNormal" style='BACKGROUND:#0f228c;LINE-HEIGHT:150%'><b><span style='FONT-SIZE:9pt;COLOR:#cccccc;LINE-HEIGHT:150%;FONT-FAMILY:Verdana'><br>
-<a href="http://www.spaconference.org/ot2004/index.shtml">
+<a href="/ot2004/index.shtml">
 										<span style='COLOR:#cccccc;
 TEXT-DECORATION:none;
 text-underline:none'>Conference</span></a><br>
-<a href="http://www.spaconference.org/ot2004/register.shtml">
+<a href="/ot2004/register.shtml">
 										<span style='COLOR:#cccccc;
 TEXT-DECORATION:none;
 text-underline:none'>Registration</span></a><br>
-<a href="http://www.spaconference.org/ot2004/programme.shtml">
+<a href="/ot2004/programme.shtml">
 										<span style='COLOR:#cccccc;
 TEXT-DECORATION:none;
 text-underline:none'>Programme</span></a><br>
-<a href="http://www.spaconference.org/ot2004/organisers.shtml"><!--			<a href="speakers.shtml" class="menu">Speakers</a><br>	--><span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>Organisers</span></a><br>
+<a href="/ot2004/organisers.shtml"><!--			<a href="speakers.shtml" class="menu">Speakers</a><br>	--><span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>Organisers</span></a><br>
 Discussion <o:p></o:p></span></b></p>
 						<div style='MARGIN-LEFT:7.5pt'>
-							<p class="MsoNormal" style='BACKGROUND:#0f228c;LINE-HEIGHT:130%'><b><span style='FONT-SIZE:7.5pt;COLOR:#cccccc;LINE-HEIGHT:130%;FONT-FAMILY:Verdana'>- <a href="http://www.spaconference.org/cgi-bin/wiki.pl" target="_blank"><span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>Wiki home</span></a><br>
-- <a href="http://www.spaconference.org/ot2004/people.shtml" target="_blank">
+							<p class="MsoNormal" style='BACKGROUND:#0f228c;LINE-HEIGHT:130%'><b><span style='FONT-SIZE:7.5pt;COLOR:#cccccc;LINE-HEIGHT:130%;FONT-FAMILY:Verdana'>- <a href="/cgi-bin/wiki.pl" target="_blank"><span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>Wiki home</span></a><br>
+- <a href="/ot2004/people.shtml" target="_blank">
 											<span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>OT people</span></a><o:p></o:p></span></b></p>
 						</div>
-						<p class="MsoNormal" style='BACKGROUND:#0f228c;LINE-HEIGHT:150%'><b><span style='FONT-SIZE:9pt;COLOR:#cccccc;LINE-HEIGHT:150%;FONT-FAMILY:Verdana'><a href="http://www.spaconference.org/ot2004/location.shtml"><!--			<a href="sponsors.shtml" class="menu">Sponsors</a><br> --><span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>Location</span></a><br>
+						<p class="MsoNormal" style='BACKGROUND:#0f228c;LINE-HEIGHT:150%'><b><span style='FONT-SIZE:9pt;COLOR:#cccccc;LINE-HEIGHT:150%;FONT-FAMILY:Verdana'><a href="/ot2004/location.shtml"><!--			<a href="sponsors.shtml" class="menu">Sponsors</a><br> --><span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>Location</span></a><br>
 <br>
 <br>
 Previous conferences <o:p></o:p></span></b></p>
 						<div style='MARGIN-LEFT:7.5pt'>
-							<p class="MsoNormal" style='BACKGROUND:#0f228c;LINE-HEIGHT:130%'><b><span style='FONT-SIZE:7.5pt;COLOR:#cccccc;LINE-HEIGHT:130%;FONT-FAMILY:Verdana'>- <a href="http://www.spaconference.org/ot2003/" target="_blank"><span style='COLOR:#cccccc;
+							<p class="MsoNormal" style='BACKGROUND:#0f228c;LINE-HEIGHT:130%'><b><span style='FONT-SIZE:7.5pt;COLOR:#cccccc;LINE-HEIGHT:130%;FONT-FAMILY:Verdana'>- <a href="/ot2003/" target="_blank"><span style='COLOR:#cccccc;
 TEXT-DECORATION:none;
 text-underline:none'>OT2003</span></a><br>
-- <a href="http://www.spaconference.org/ot2002/" target="_blank">
+- <a href="/ot2002/" target="_blank">
 											<span style='COLOR:#cccccc;
 TEXT-DECORATION:none;
 text-underline:none'>OT2002</span></a><br>
-- <a href="http://www.spaconference.org/ot2001/" target="_blank">
+- <a href="/ot2001/" target="_blank">
 											<span style='COLOR:#cccccc;
 TEXT-DECORATION:none;
 text-underline:none'>OT2001</span></a><br>
-- <a href="http://www.spaconference.org/ot2000" target="_blank">
+- <a href="/ot2000" target="_blank">
 											<span style='COLOR:#cccccc;
 TEXT-DECORATION:none;
 text-underline:none'>OT2000</span></a> <o:p></o:p></span></b></p>
@@ -166,12 +166,12 @@ text-underline:none'>OT2000</span></a> <o:p></o:p></span></b></p>
 									<span style='TEXT-DECORATION:
 none;text-underline:
 none'>
-										<img border="0" width="37" height="36" id="_x0000_i1026" src="http://www.spaconference.org/ot2004/images/smallbcslogo.gif"
+										<img border="0" width="37" height="36" id="_x0000_i1026" src="/ot2004/images/smallbcslogo.gif"
 											alt="BCS"></span></a><o:p></o:p></span></p>
 					</div>
 			</td><td>
-			<p class="MsoNormal" align="right" style='LINE-HEIGHT:180%;TEXT-ALIGN:right'><b><span style='FONT-SIZE:8.5pt;COLOR:#cccccc;LINE-HEIGHT:180%;FONT-FAMILY:Verdana'><a href="http://www.spaconference.org/ot2004/register.shtml"><span class="GramE"><span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>registration</span></span></a>
-- <a href="http://www.spaconference.org/ot2004/organisers.shtml"><span style='COLOR:#cccccc;
+			<p class="MsoNormal" align="right" style='LINE-HEIGHT:180%;TEXT-ALIGN:right'><b><span style='FONT-SIZE:8.5pt;COLOR:#cccccc;LINE-HEIGHT:180%;FONT-FAMILY:Verdana'><a href="/ot2004/register.shtml"><span class="GramE"><span style='COLOR:#cccccc;TEXT-DECORATION:none;text-underline:none'>registration</span></span></a>
+- <a href="/ot2004/organisers.shtml"><span style='COLOR:#cccccc;
 TEXT-DECORATION:none;
 text-underline:none'>contact</span></a>&nbsp; <o:p></o:p></span></b></p>
 			<div id="contentcontent">
@@ -187,7 +187,7 @@ mso-hide:all'><o:p>&nbsp;</o:p>
 					</span></p>
 					
 					<!-- SELECTION TABLE -->
-			<form action="http://www.spaconference.org/cgi-bin/selectSunday.pl">
+			<form action="/cgi-bin/selectSunday.pl">
 				<table class="MsoNormalTable" border="1" cellpadding="0" width="98%" style='WIDTH:98.76%;mso-cellspacing:1.5pt'>
 					<tr style='mso-yfti-irow:0;mso-yfti-firstrow:yes'>
 						<td>
@@ -195,9 +195,9 @@ mso-hide:all'><o:p>&nbsp;</o:p>
   COLOR:#666666;
   LINE-HEIGHT:120%;
   FONT-FAMILY:Verdana'>WG1</span><span style='FONT-SIZE:9pt;COLOR:#666666;LINE-HEIGHT:120%;FONT-FAMILY:Verdana'><br>
-  <a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdaecabhcoproxyfavayacomKk"
+  <a href="/cgi-bin/wiki.pl/ot2004/?KkbagdaecabhcoproxyfavayacomKk"
 										target="session"><b>Seeing the forest and the trees </b></a><br>
-  <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartineDevos&amp;type=bio" target="person">Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DianeGibson&amp;type=bio" target="person">Diane&nbsp;Gibson</a> <o:p></o:p></span></p>
+  <a href="/cgi-bin/wiki.pl/?browse=MartineDevos&amp;type=bio" target="person">Martine&nbsp;Devos</a> <i>Avaya&nbsp;Inc.</i>, <a href="/cgi-bin/wiki.pl/?browse=DianeGibson&amp;type=bio" target="person">Diane&nbsp;Gibson</a> <o:p></o:p></span></p>
 							<p class="MsoNormal" style='LINE-HEIGHT:120%'><span style='FONT-SIZE:9pt;
   COLOR:#666666;
   LINE-HEIGHT:120%;
@@ -216,9 +216,9 @@ mso-hide:all'><o:p>&nbsp;</o:p>
   COLOR:#666666;
   LINE-HEIGHT:120%;
   FONT-FAMILY:Verdana'>WG3</span><span style='FONT-SIZE:9pt;COLOR:#666666;LINE-HEIGHT:120%;FONT-FAMILY:Verdana'><br>
-									<a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbagdcabhifgcibaabfcKk" target="session">
+									<a href="/cgi-bin/wiki.pl/ot2004/?KkbagdcabhifgcibaabfcKk" target="session">
 										<b>Getting the message?</b></a><br>
-									<a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DavidBell&amp;type=bio" target="person">
+									<a href="/cgi-bin/wiki.pl/?browse=DavidBell&amp;type=bio" target="person">
 										David&nbsp;Bell</a> <i>MFESD<o:p></o:p></i></span></p>
 							<p class="MsoNormal" style='LINE-HEIGHT:120%'><i><span style='FONT-SIZE:9pt;
   COLOR:#666666;
@@ -239,9 +239,9 @@ mso-hide:all'><o:p>&nbsp;</o:p>
   COLOR:#666666;
   LINE-HEIGHT:120%;
   FONT-FAMILY:Verdana'>WG4</span><span style='FONT-SIZE:9pt;COLOR:#666666;LINE-HEIGHT:120%;FONT-FAMILY:Verdana'><br>
-									<a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbahdfgchbdKk" target="session">
+									<a href="/cgi-bin/wiki.pl/ot2004/?KkbahdfgchbdKk" target="session">
 										<b>Xbots</b></a><br>
-									<a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=DuncanPierce&amp;type=bio" target="person">
+									<a href="/cgi-bin/wiki.pl/?browse=DuncanPierce&amp;type=bio" target="person">
 										Duncan&nbsp;Pierce</a> <i>Amarinda<o:p></o:p></i></span></p>
 							<p class="MsoNormal" style='LINE-HEIGHT:120%'><i><span style='FONT-SIZE:9pt;
   COLOR:#666666;
@@ -264,9 +264,9 @@ mso-hide:all'><o:p>&nbsp;</o:p>
   COLOR:#666666;
   LINE-HEIGHT:120%;
   FONT-FAMILY:Verdana'>TU11</span><span style='FONT-SIZE:9pt;COLOR:#666666;LINE-HEIGHT:120%;FONT-FAMILY:Verdana'><br>
-									<a href="http://www.spaconference.org/cgi-bin/wiki.pl/ot2004/?KkbahdfgcjfdKk" target="session">
+									<a href="/cgi-bin/wiki.pl/ot2004/?KkbahdfgcjfdKk" target="session">
 										<b>UML 1++</b></a><br>
-									<a href="http://www.spaconference.org/cgi-bin/wiki.pl/?browse=MartinFowler&amp;type=bio" target="person">
+									<a href="/cgi-bin/wiki.pl/?browse=MartinFowler&amp;type=bio" target="person">
 										Martin&nbsp;Fowler</a> <i>ThoughtWorks<o:p></o:p></i></span></p>
 							<P class="MsoNormal" style="LINE-HEIGHT: 120%"><span style='FONT-SIZE:9pt; background=#ffffa0; COLOR:#000000;
   LINE-HEIGHT:120%;

--- a/ot2004/uploadTheNewProgramme.html
+++ b/ot2004/uploadTheNewProgramme.html
@@ -1,6 +1,6 @@
 <html><body>
   <h1>Upload OT Programme</h1>
-  <form method="POST" action="http://www.spaconference.org/cgi-bin/upload.pl" enctype="multipart/form-data">
+  <form method="POST" action="/cgi-bin/upload.pl" enctype="multipart/form-data">
   <table>
     <tr><td>Programme Template file:</td><td><input type="file" size=20 name="u1f" value=""> (unchanged if blank)</td></tr>
     <tr><td>Tag file:</td><td><input type=file size=20 name=u2f value=""> (unchanged if blank)</td></tr>
@@ -11,6 +11,6 @@
   </form>
   When you first want to update the real programme, ask Alan to unlock the programme placeholder.
   <hr>
-  <a href="http://www.spaconference.org/cgi-bin/wiki.pl/submissions/?edit=new+submission&type=submission">Click here to create a new session.</a>
+  <a href="/cgi-bin/wiki.pl/submissions/?edit=new+submission&type=submission">Click here to create a new session.</a>
 </body>
 </html>


### PR DESCRIPTION
There are very few links to spaconference.org in the OT sites, the main one being the client-side redirect to the homepage. Unfortunately there are lots of missing pages from these sites; they got lost in a CMS move many many years ago (before my time).

I doubt anyone is looking at these, but just doing for completeness!

Already deployed to the server.