### PR TITLE
Update all remaining absolute links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Previous SPA Sites
 
-The website for [SPA conference](http://www.spaconference.org/) links to the sites for previous years. This repo contains those sites.
+The website for [SPA conference](https://www.spaconference.org/) links to the sites for previous years. This repo contains those sites.
 
 If the hosting is moved somewhere else, this repo can be used to populate the old sites, but for now it's just a copy of what is on the server.

--- a/spa2017/book-now.html
+++ b/spa2017/book-now.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -103,4 +103,4 @@
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2017/formats.html
+++ b/spa2017/formats.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -81,17 +81,17 @@
 <ul>
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/themes.html"><span>Conference Themes</span></a>
+<li><a href="/spa2017/themes.html"><span>Conference Themes</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/formats.html"><span>Formats</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/formats.html"><span>Formats</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/submission-stages.html"><span>Submission stages</span></a>
+<li><a href="/spa2017/submission-stages.html"><span>Submission stages</span></a>
 
 
 </li></ul></li>
@@ -102,17 +102,17 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/themes.html"><span>Conference Themes</span></a>
+<li><a href="/spa2017/themes.html"><span>Conference Themes</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/formats.html"><span>Formats</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/formats.html"><span>Formats</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/submission-stages.html"><span>Submission stages</span></a>
+<li><a href="/spa2017/submission-stages.html"><span>Submission stages</span></a>
 
 
 </li>
@@ -178,4 +178,4 @@
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2017/karen-shoop.html
+++ b/spa2017/karen-shoop.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -99,4 +99,4 @@ Dr Karen Shoop is a Researcher at the Queen Mary University's School of Electron
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2017/location.html
+++ b/spa2017/location.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -84,7 +84,7 @@ The Davidson Building
 5 Southampton Street
 London WC2E 7HA</address>
 <p>Tel: 01793 417666 / Fax: 01793 417669</p>
-<p>Full joining instructions including maps and information on how best to travel to the conference are available <a href="http://spaconference.org/spa2014/joining-instructions.html">here</a>.</p>
+<p>Full joining instructions including maps and information on how best to travel to the conference are available <a href="/spa2014/joining-instructions.html">here</a>.</p>
 <p>Once you are in Southampton Street, just look out for the very distinctive clock over the doorway to the The Davidson Building. </p>
 <p>When you have signed in with security, please head up to the first floor where the conference will take place.</p>
   </main>

--- a/spa2017/nocookies.html
+++ b/spa2017/nocookies.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -95,4 +95,4 @@
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2017/organisers.html
+++ b/spa2017/organisers.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -121,4 +121,4 @@ eval(unescape('%64%6f%63%75%6d%65%6e%74%2e%77%72%69%74%65%28%27%3c%61%20%68%72%6
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2017/previousconferences.html
+++ b/spa2017/previousconferences.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -80,7 +80,7 @@
   
 <ul>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>

--- a/spa2017/refunds-and-cancellations.html
+++ b/spa2017/refunds-and-cancellations.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -99,4 +99,4 @@
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2017/sponsor.html
+++ b/spa2017/sponsor.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -136,4 +136,4 @@
   </p>
 </div></footer>
 <script>/* <![CDATA[ */(function(d,s,a,i,j,r,l,m,t){try{l=d.getElementsByTagName('a');t=d.createElement('textarea');for(i=0;l.length-i;i++){try{a=l[i].href;s=a.indexOf('/cdn-cgi/l/email-protection');m=a.length;if(a&&s>-1&&m>28){j=28+s;s='';if(j<m){r='0x'+a.substr(j,2)|0;for(j+=2;j<m&&a.charAt(j)!='X';j+=2)s+='%'+('0'+('0x'+a.substr(j,2)^r).toString(16)).slice(-2);j++;s=decodeURIComponent(s)+a.substr(j,m-j)}t.innerHTML=s.replace(/</g,'&lt;').replace(/\>/g,'&gt;');l[i].href='mailto:'+t.value}}catch(e){}}}catch(e){}})(document);/* ]]> */</script></body>
-</html>
+</html>

--- a/spa2017/sponsors.html
+++ b/spa2017/sponsors.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -76,7 +76,7 @@
         <main>
     <p>We are grateful to our conference sponsors for providing resources and time to make SPA2017 a success.</p>
 
-<a href="https://www.contino.io" title="Contino"><img src="http://spaconference.org/spa2017/uploads/images/Contino_Logo_DarkGrey_Large_Web.png" width="600" height="218" alt="[Contino_Logo_DarkGrey_Large_Web.png]" title="[Contino_Logo_DarkGrey_Large_Web.png]"/>
+<a href="https://www.contino.io" title="Contino"><img src="/spa2017/uploads/images/Contino_Logo_DarkGrey_Large_Web.png" width="600" height="218" alt="[Contino_Logo_DarkGrey_Large_Web.png]" title="[Contino_Logo_DarkGrey_Large_Web.png]"/>
 </a> 
 <p>Contino is an industry leading transformational technical consultancy. We partner with the world's leading brands to accelerate innovation through the successful adoption of Enterprise DevOps and Cloud-Native approaches.</p>
 
@@ -94,4 +94,4 @@
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2017/submission-stages.html
+++ b/spa2017/submission-stages.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -81,17 +81,17 @@
 <ul>
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/themes.html"><span>Conference Themes</span></a>
+<li><a href="/spa2017/themes.html"><span>Conference Themes</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/formats.html"><span>Formats</span></a>
+<li><a href="/spa2017/formats.html"><span>Formats</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/submission-stages.html"><span>Submission stages</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/submission-stages.html"><span>Submission stages</span></a>
 
 
 </li></ul></li>
@@ -102,17 +102,17 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/themes.html"><span>Conference Themes</span></a>
+<li><a href="/spa2017/themes.html"><span>Conference Themes</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/formats.html"><span>Formats</span></a>
+<li><a href="/spa2017/formats.html"><span>Formats</span></a>
 
 
 </li>
 
-        <li class="menuactive"><a class="menuactive" href="http://spaconference.org/spa2017/submission-stages.html"><span>Submission stages</span></a>
+        <li class="menuactive"><a class="menuactive" href="/spa2017/submission-stages.html"><span>Submission stages</span></a>
 
 
 </li>
@@ -175,4 +175,4 @@
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2017/terms-and-conditions.html
+++ b/spa2017/terms-and-conditions.html
@@ -15,7 +15,7 @@
   <h1>
     <img alt="BCS" src="images/bcslogo.png" width="65" height="69">
     
-     <a href="http://spaconference.org/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
+     <a href="/spa2017/" title="Home Page, shortcut key=1" ><span class="conference-name">SPA<wbr><em>2017</em></span></a>
   </h1>
     <nav>
      
@@ -23,37 +23,37 @@
   
 <ul>
 
-<li><a href="http://spaconference.org/spa2017/programme.html"><span>Programme</span></a>
+<li><a href="/spa2017/programme.html"><span>Programme</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsor.html"><span>Sponsor Us</span></a>
+<li><a href="/spa2017/sponsor.html"><span>Sponsor Us</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/sponsors.html"><span>Sponsors</span></a>
+<li><a href="/spa2017/sponsors.html"><span>Sponsors</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/organisers.html"><span>Organisers</span></a>
+<li><a href="/spa2017/organisers.html"><span>Organisers</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/location.html"><span>Location</span></a>
+<li><a href="/spa2017/location.html"><span>Location</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
+<li><a href="/spa2017/previousconferences.html"><span>Previous Conferences</span></a>
 
 
 </li>
 
-<li><a href="http://spaconference.org/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
+<li><a href="/spa2017/code-of-conduct.html"><span>Code of Conduct</span></a>
 
 
 </li>
@@ -105,4 +105,4 @@
   </p>
 </div></footer>
 </body>
-</html>
+</html>

--- a/spa2018/announcements/event-storming/ddd/sessions/2018/05/28/yves-event-storming.html
+++ b/spa2018/announcements/event-storming/ddd/sessions/2018/05/28/yves-event-storming.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/announcements/iot/2018/06/26/maisie-venus-iot.html
+++ b/spa2018/announcements/iot/2018/06/26/maisie-venus-iot.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/announcements/keynotes/2018/02/28/launching-spa-2018.html
+++ b/spa2018/announcements/keynotes/2018/02/28/launching-spa-2018.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/announcements/keynotes/2018/04/10/alicia-keynote.html
+++ b/spa2018/announcements/keynotes/2018/04/10/alicia-keynote.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/announcements/sketching/2018/06/03/rizwan-sketching.html
+++ b/spa2018/announcements/sketching/2018/06/03/rizwan-sketching.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   
@@ -118,7 +118,7 @@
     <main>
       <p>Sketching is an easily overlooked skill for developers and everyone else, yet the benefits that sketching brings cannot be overstated. Many of us feel that we weren’t born with artistic talent and so we try to avoid it as much as possible.</p>
 
-<p>Perhaps we’re making a big mistake, though. Rizwan Javaid claims we can all become skilled sketchers and he will be <a href="https://spaconference.org/spa2018/sessions/session768.html">teaching us</a> how at SPA Software in Practice 2018.</p>
+<p>Perhaps we’re making a big mistake, though. Rizwan Javaid claims we can all become skilled sketchers and he will be <a href="/spa2018/sessions/session768.html">teaching us</a> how at SPA Software in Practice 2018.</p>
 
 <p><img src="/spa2018/images/2018/rizwan_banner.png" style="display: block; margin-left: auto; margin-right: auto;" alt="Rizwan Javaid" /></p>
 

--- a/spa2018/bofs.html
+++ b/spa2018/bofs.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/book-now.html
+++ b/spa2018/book-now.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/code-of-conduct.html
+++ b/spa2018/code-of-conduct.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/index.html
+++ b/spa2018/index.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/info-for-speakers.html
+++ b/spa2018/info-for-speakers.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/interactivity.html
+++ b/spa2018/interactivity.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/lead-a-session.html
+++ b/spa2018/lead-a-session.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   
@@ -145,7 +145,7 @@
 <p>We particularly encourage speakers who are new to presenting at SPA Software in Practice. If you submit early, our feedback process will allow you to tune your proposal before the final review stage.</p>
 
 <h2>The submission and selection process</h2>
-<p>To submit your proposal, complete the <a href="https://spaconference.org/scripts/makeproposal.php">form on the website</a>.</p>
+<p>To submit your proposal, complete the <a href="/scripts/makeproposal.php">form on the website</a>.</p>
 <p>Your submission is completely anonymous right up until we have the draft programme - then we just check no-one has too many sessions in, or several at the same time.</p>
 <p>All sessions submitted by 10pm on 21st January 2018 will receive feedback to help improve the proposal.</p>
 <p>Submissions can be edited until the final deadline of 10pm on 18th February 2018.</p>

--- a/spa2018/location.html
+++ b/spa2018/location.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/news.html
+++ b/spa2018/news.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/no-cookies.html
+++ b/spa2018/no-cookies.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/organisers.html
+++ b/spa2018/organisers.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/previous-conferences.html
+++ b/spa2018/previous-conferences.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   
@@ -116,27 +116,27 @@
     
       <nav>
         <ul>
-  <li><a href="https://spaconference.org/spa2017/"><span>SPA2017</span></a></li>
-  <li><a href="https://spaconference.org/spa2016/"><span>SPA2016</span></a></li>
-  <li><a href="https://spaconference.org/spa2015/"><span>SPA2015</span></a></li>
-  <li><a href="https://spaconference.org/spa2014/"><span>SPA2014</span></a></li>
-  <li><a href="https://spaconference.org/spa2013/"><span>SPA2013</span></a></li>
-  <li><a href="https://spaconference.org/spa2012/"><span>SPA2012</span></a></li>
-  <li><a href="https://spaconference.org/spa2011/"><span>SPA2011</span></a></li>
-  <li><a href="https://spaconference.org/spa2010/"><span>SPA2010</span></a></li>
-  <li><a href="https://spaconference.org/spa2009/"><span>SPA2009</span></a></li>
-  <li><a href="https://spaconference.org/spa2008/"><span>SPA2008</span></a></li>
-  <li><a href="https://spaconference.org/spa2007/"><span>SPA2007</span></a></li>
-  <li><a href="https://spaconference.org/spa2006/"><span>SPA2006</span></a></li>
-  <li><a href="https://spaconference.org/spa2005/"><span>SPA2005</span></a></li>
-  <li><a href="https://spaconference.org/ot2004/"><span>OT2004</span></a></li>
-  <li><a href="https://spaconference.org/ot2003/"><span>OT2003</span></a></li>
-  <li><a href="https://spaconference.org/ot2002/"><span>OT2002</span></a></li>
-  <li><a href="https://spaconference.org/ot2001/"><span>OT2001</span></a></li>
-  <li><a href="https://spaconference.org/ot2000/index.htm"><span>OT2000</span></a></li>
-  <li><a href="https://spaconference.org/ot99/"><span>OT99</span></a></li>
-  <li><a href="https://spaconference.org/ot98/"><span>OT98</span></a></li>
-  <li><a href="https://spaconference.org/ot97/"><span>OT97</span></a></li>
+  <li><a href="/spa2017/"><span>SPA2017</span></a></li>
+  <li><a href="/spa2016/"><span>SPA2016</span></a></li>
+  <li><a href="/spa2015/"><span>SPA2015</span></a></li>
+  <li><a href="/spa2014/"><span>SPA2014</span></a></li>
+  <li><a href="/spa2013/"><span>SPA2013</span></a></li>
+  <li><a href="/spa2012/"><span>SPA2012</span></a></li>
+  <li><a href="/spa2011/"><span>SPA2011</span></a></li>
+  <li><a href="/spa2010/"><span>SPA2010</span></a></li>
+  <li><a href="/spa2009/"><span>SPA2009</span></a></li>
+  <li><a href="/spa2008/"><span>SPA2008</span></a></li>
+  <li><a href="/spa2007/"><span>SPA2007</span></a></li>
+  <li><a href="/spa2006/"><span>SPA2006</span></a></li>
+  <li><a href="/spa2005/"><span>SPA2005</span></a></li>
+  <li><a href="/ot2004/"><span>OT2004</span></a></li>
+  <li><a href="/ot2003/"><span>OT2003</span></a></li>
+  <li><a href="/ot2002/"><span>OT2002</span></a></li>
+  <li><a href="/ot2001/"><span>OT2001</span></a></li>
+  <li><a href="/ot2000/index.htm"><span>OT2000</span></a></li>
+  <li><a href="/ot99/"><span>OT99</span></a></li>
+  <li><a href="/ot98/"><span>OT98</span></a></li>
+  <li><a href="/ot97/"><span>OT97</span></a></li>
 </ul>
 
       </nav>

--- a/spa2018/programme_includes/header.html
+++ b/spa2018/programme_includes/header.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/programme_includes/person_header.html
+++ b/spa2018/programme_includes/person_header.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/programme_includes/session_header.html
+++ b/spa2018/programme_includes/session_header.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/social.html
+++ b/spa2018/social.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/sponsor.html
+++ b/spa2018/sponsor.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/sponsors.html
+++ b/spa2018/sponsors.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/submission-stages.html
+++ b/spa2018/submission-stages.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2018/terms-and-conditions.html
+++ b/spa2018/terms-and-conditions.html
@@ -37,7 +37,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2018/programme.html">
+    <li><a href="/spa2018/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -93,7 +93,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My Spa</span>
     </a></li>
   

--- a/spa2019/2019/02/18/launching-spa-2019-keynotes.html
+++ b/spa2019/2019/02/18/launching-spa-2019-keynotes.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/announcements/keynotes/2019/02/18/launching-spa-2019-keynotes.html
+++ b/spa2019/announcements/keynotes/2019/02/18/launching-spa-2019-keynotes.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/bof.html
+++ b/spa2019/bof.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/book-now.html
+++ b/spa2019/book-now.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/code-of-conduct.html
+++ b/spa2019/code-of-conduct.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/index.html
+++ b/spa2019/index.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/info-for-speakers.html
+++ b/spa2019/info-for-speakers.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/interactivity.html
+++ b/spa2019/interactivity.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/lead-a-session.html
+++ b/spa2019/lead-a-session.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   
@@ -146,7 +146,7 @@
 		<p>Anyone involved in the process of developing software, whatever your role - product manager, artist, developer, musician, business analyst, designer...</p>
 		<p>We particularly encourage speakers who are new to presenting at SPA Software in Practice. If you submit early, our feedback process will allow you to tune your proposal before the final review stage.</p>
 	<h2>The submission and selection process</h2>
-		<p>To submit your proposal, complete the <a href="https://spaconference.org/scripts/makeproposal.php">Submit a proposal for a session</a> form.</p>
+		<p>To submit your proposal, complete the <a href="/scripts/makeproposal.php">Submit a proposal for a session</a> form.</p>
 		<p>Your submission is completely anonymous right up until we have the draft programme - then we just check no-one has too many sessions in, or several at the same time.</p>
 		<p>All sessions submitted by 11:59 PM on 21st January 2019 will receive feedback to help improve the proposal.</p>
 		<p>Submissions can be edited until the final deadline of 11:59 PM on 24th February 2019.</p>
@@ -161,7 +161,7 @@
 		<p>Submissions submitted before 11:59 PM on 21st January 2019 will receive feedback and may be resubmitted.</p>
 		<p>Submissions deadline: 11:59 PM, 24th February 2019</p>
 		<p>Programme announced: End-April 2019</p>
-		<p>If you want to be notified when the important dates are coming up, please register at <a href="https://spaconference.org/scripts/myprofile.php">My SPA</a> and select the option to receive communications by us.</p>
+		<p>If you want to be notified when the important dates are coming up, please register at <a href="/scripts/myprofile.php">My SPA</a> and select the option to receive communications by us.</p>
 		<p>If you're uncertain about whether to submit your idea, or have other queries, please feel free to get in touch with us at</p>
 		<p><em>programme@spaconference.org</em></p>
 		<p>Jason Ayers, Programme Chair, SPA Software in Practice 2019</p>

--- a/spa2019/location.html
+++ b/spa2019/location.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/news.html
+++ b/spa2019/news.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <!--<a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>-->
-  <h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>
+  <h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>
 
   <nav>
 <ul>
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/no-cookies.html
+++ b/spa2019/no-cookies.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/organisers.html
+++ b/spa2019/organisers.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/previous-conferences.html
+++ b/spa2019/previous-conferences.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   
@@ -118,28 +118,28 @@
     
       <nav>
         <ul>
-  <li><a href="https://spaconference.org/spa2018/"><span>SPA Software in Practice 2018</span></a></li>
-  <li><a href="https://spaconference.org/spa2017/"><span>SPA2017</span></a></li>
-  <li><a href="https://spaconference.org/spa2016/"><span>SPA2016</span></a></li>
-  <li><a href="https://spaconference.org/spa2015/"><span>SPA2015</span></a></li>
-  <li><a href="https://spaconference.org/spa2014/"><span>SPA2014</span></a></li>
-  <li><a href="https://spaconference.org/spa2013/"><span>SPA2013</span></a></li>
-  <li><a href="https://spaconference.org/spa2012/"><span>SPA2012</span></a></li>
-  <li><a href="https://spaconference.org/spa2011/"><span>SPA2011</span></a></li>
-  <li><a href="https://spaconference.org/spa2010/"><span>SPA2010</span></a></li>
-  <li><a href="https://spaconference.org/spa2009/"><span>SPA2009</span></a></li>
-  <li><a href="https://spaconference.org/spa2008/"><span>SPA2008</span></a></li>
-  <li><a href="https://spaconference.org/spa2007/"><span>SPA2007</span></a></li>
-  <li><a href="https://spaconference.org/spa2006/"><span>SPA2006</span></a></li>
-  <li><a href="https://spaconference.org/spa2005/"><span>SPA2005</span></a></li>
-  <li><a href="https://spaconference.org/ot2004/"><span>OT2004</span></a></li>
-  <li><a href="https://spaconference.org/ot2003/"><span>OT2003</span></a></li>
-  <li><a href="https://spaconference.org/ot2002/"><span>OT2002</span></a></li>
-  <li><a href="https://spaconference.org/ot2001/"><span>OT2001</span></a></li>
-  <li><a href="https://spaconference.org/ot2000/index.htm"><span>OT2000</span></a></li>
-  <li><a href="https://spaconference.org/ot99/"><span>OT99</span></a></li>
-  <li><a href="https://spaconference.org/ot98/"><span>OT98</span></a></li>
-  <li><a href="https://spaconference.org/ot97/"><span>OT97</span></a></li>
+  <li><a href="/spa2018/"><span>SPA Software in Practice 2018</span></a></li>
+  <li><a href="/spa2017/"><span>SPA2017</span></a></li>
+  <li><a href="/spa2016/"><span>SPA2016</span></a></li>
+  <li><a href="/spa2015/"><span>SPA2015</span></a></li>
+  <li><a href="/spa2014/"><span>SPA2014</span></a></li>
+  <li><a href="/spa2013/"><span>SPA2013</span></a></li>
+  <li><a href="/spa2012/"><span>SPA2012</span></a></li>
+  <li><a href="/spa2011/"><span>SPA2011</span></a></li>
+  <li><a href="/spa2010/"><span>SPA2010</span></a></li>
+  <li><a href="/spa2009/"><span>SPA2009</span></a></li>
+  <li><a href="/spa2008/"><span>SPA2008</span></a></li>
+  <li><a href="/spa2007/"><span>SPA2007</span></a></li>
+  <li><a href="/spa2006/"><span>SPA2006</span></a></li>
+  <li><a href="/spa2005/"><span>SPA2005</span></a></li>
+  <li><a href="/ot2004/"><span>OT2004</span></a></li>
+  <li><a href="/ot2003/"><span>OT2003</span></a></li>
+  <li><a href="/ot2002/"><span>OT2002</span></a></li>
+  <li><a href="/ot2001/"><span>OT2001</span></a></li>
+  <li><a href="/ot2000/index.htm"><span>OT2000</span></a></li>
+  <li><a href="/ot99/"><span>OT99</span></a></li>
+  <li><a href="/ot98/"><span>OT98</span></a></li>
+  <li><a href="/ot97/"><span>OT97</span></a></li>
 </ul>
 
       </nav>

--- a/spa2019/programme.html
+++ b/spa2019/programme.html
@@ -75,7 +75,7 @@
 </li><li class="all-tracks">
   <h3><span class='time'>13:30  -  14:30</span></h3>
   <div>
-    <h4><a href="https://www.spaconference.org/spa2019/simon-brown.html">The Lost Art of Software Design</a></h4>
+    <h4><a href="/spa2019/simon-brown.html">The Lost Art of Software Design</a></h4>
     <ul><li>Simon Brown</li></ul>
   </div>
 </li><li class="all-tracks break">
@@ -248,7 +248,7 @@
 </li><li class="all-tracks">
   <h3><span class='time'>13:00  -  14:00</span></h3>
   <div>
-    <h4><a href="https://www.spaconference.org/spa2019/rachel-davies.html">Sustaining Remote-First Teams</a></h4>
+    <h4><a href="/spa2019/rachel-davies.html">Sustaining Remote-First Teams</a></h4>
     <ul><li>Rachel Davies</li></ul>
   </div>
 </li><li class="all-tracks break">
@@ -438,7 +438,7 @@
 </li><li class="all-tracks">
   <h3><span class='time'>14:30  -  15:30</span></h3>
   <div>
-    <h4><a href="https://www.spaconference.org/spa2019/torgeir-dingsoyr.html">Agile Development in Large-Scale: Challenges and Insight for Research</a></h4>
+    <h4><a href="/spa2019/torgeir-dingsoyr.html">Agile Development in Large-Scale: Challenges and Insight for Research</a></h4>
     <ul><li>Torgeir Dingsøyr</li></ul>
   </div>
 </li><li class="all-tracks">

--- a/spa2019/programme_includes/header.html
+++ b/spa2019/programme_includes/header.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/programme_includes/person_header.html
+++ b/spa2019/programme_includes/person_header.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/programme_includes/session_header.html
+++ b/spa2019/programme_includes/session_header.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/rachel-davies.html
+++ b/spa2019/rachel-davies.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/simon-brown.html
+++ b/spa2019/simon-brown.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/social.html
+++ b/spa2019/social.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/sponsor.html
+++ b/spa2019/sponsor.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/sponsors.html
+++ b/spa2019/sponsors.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/submission-stages.html
+++ b/spa2019/submission-stages.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/successful-sessions.html
+++ b/spa2019/successful-sessions.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   
@@ -134,33 +134,33 @@
 	<p>Here are a sample of successful sessions that respresent something of the eclectic mix of past conference sessions from the last 4 years.</p>
 	<p>Hopefully these past contributions give you a flavour of the kind of we are looking for in this year's sessions. They are the actual submissions made by the session leaders when applying so hopefully they will also be helpful in guiding your own submissions in terms of the level of information needed.</p>
 	<ul>
-  		<li><a href="https://spaconference.org/spa2017/sessions/session715.html"><span>A Breathless Tour of Blockchain</span></a></li>
- 		<li><a href="https://spaconference.org/spa2017/sessions/session694.html"><span>Access control for REST services</span></a></li>
- 		<li><a href="https://spaconference.org/spa2017/sessions/session727.html"><span>Adopting Kotlin - How We Learned to Stop Worrying and Love the Null</span></a></li>
- 		<li><a href="https://www.spaconference.org/spa2015/sessions/session623.html"><span>Analysing GitHub commits with R</span></a></li>
- 		<li><a href="https://spaconference.org/spa2018/sessions/session791.html"><span>Become a Fantastic Facilitator</span></a></li>
- 		<li><a href="https://spaconference.org/spa2018/sessions/session751.html"><span>Behind the AI Curtain - Designing for Trust in Machine Learning Products</span></a></li>
- 		<li><a href="https://spaconference.org/spa2018/sessions/session815.html"><span>Better Whiteboard Sketches</span></a></li>
- 		<li><a href="https://www.spaconference.org/spa2015/sessions/session643.html"><span>Exploring Emergent Design with TDD</span></a></li>
- 		<li><a href="https://www.spaconference.org/spa2014/sessions/session566.html"><span>*Getting Started with Data Science</span></a></li>
- 		<li><a href="https://www.spaconference.org/spa2014/sessions/session595.html"><span>Less mocking, less brittle tests</span></a></li>
- 		<li><a href="https://spaconference.org/spa2018/sessions/session802.html"><span>Negotiating For Your Life</span></a></li>
- 		<li><a href="https://www.spaconference.org/spa2015/sessions/session603.html"><span>#NoEstimates does not mean "no estimates"</span></a></li>
- 		<li><a href="https://spaconference.org/spa2017/sessions/session732.html"><span>Painting the Business Model Canvas</span></a></li>
- 		<li><a href="https://www.spaconference.org/spa2015/sessions/session601.html"><span>Recycling tests in TDD</span></a></li>
- 		<li><a href="https://spaconference.org/spa2018/sessions/session813.html"><span>Secure Code Development in Practice</span></a></li>
- 		<li><a href="https://spaconference.org/spa2018/sessions/session809.html"><span>Typing is not the hard part - Developing a culture of pair programming</span></a></li>
- 		<li><a href="https://spaconference.org/spa2017/sessions/session700.html"><span>Visualising Connascence to Drive Refactoring</span></a></li>
+  		<li><a href="/spa2017/sessions/session715.html"><span>A Breathless Tour of Blockchain</span></a></li>
+ 		<li><a href="/spa2017/sessions/session694.html"><span>Access control for REST services</span></a></li>
+ 		<li><a href="/spa2017/sessions/session727.html"><span>Adopting Kotlin - How We Learned to Stop Worrying and Love the Null</span></a></li>
+ 		<li><a href="/spa2015/sessions/session623.html"><span>Analysing GitHub commits with R</span></a></li>
+ 		<li><a href="/spa2018/sessions/session791.html"><span>Become a Fantastic Facilitator</span></a></li>
+ 		<li><a href="/spa2018/sessions/session751.html"><span>Behind the AI Curtain - Designing for Trust in Machine Learning Products</span></a></li>
+ 		<li><a href="/spa2018/sessions/session815.html"><span>Better Whiteboard Sketches</span></a></li>
+ 		<li><a href="/spa2015/sessions/session643.html"><span>Exploring Emergent Design with TDD</span></a></li>
+ 		<li><a href="/spa2014/sessions/session566.html"><span>*Getting Started with Data Science</span></a></li>
+ 		<li><a href="/spa2014/sessions/session595.html"><span>Less mocking, less brittle tests</span></a></li>
+ 		<li><a href="/spa2018/sessions/session802.html"><span>Negotiating For Your Life</span></a></li>
+ 		<li><a href="/spa2015/sessions/session603.html"><span>#NoEstimates does not mean "no estimates"</span></a></li>
+ 		<li><a href="/spa2017/sessions/session732.html"><span>Painting the Business Model Canvas</span></a></li>
+ 		<li><a href="/spa2015/sessions/session601.html"><span>Recycling tests in TDD</span></a></li>
+ 		<li><a href="/spa2018/sessions/session813.html"><span>Secure Code Development in Practice</span></a></li>
+ 		<li><a href="/spa2018/sessions/session809.html"><span>Typing is not the hard part - Developing a culture of pair programming</span></a></li>
+ 		<li><a href="/spa2017/sessions/session700.html"><span>Visualising Connascence to Drive Refactoring</span></a></li>
 	</ul>
 </div>
 <div>
 	<br />
 	<p>Here are the programmes for the past four conferences if you want to get a broader feel.</p>
 	<ul>
-  		<li><a href="https://spaconference.org/spa2018/programme.html"><span>SPA Software in Practice 2018 Programme</span></a></li>
-		<li><a href="https://spaconference.org/spa2017/programme.html"><span>SPA2017 Programme</span></a></li>
-		<li><a href="https://spaconference.org/spa2016/programme.html"><span>SPA2016 Programme</span></a></li>
-		<li><a href="https://spaconference.org/spa2015/programme.html"><span>SPA2015 Programme</span></a></li>
+  		<li><a href="/spa2018/programme.html"><span>SPA Software in Practice 2018 Programme</span></a></li>
+		<li><a href="/spa2017/programme.html"><span>SPA2017 Programme</span></a></li>
+		<li><a href="/spa2016/programme.html"><span>SPA2016 Programme</span></a></li>
+		<li><a href="/spa2015/programme.html"><span>SPA2015 Programme</span></a></li>
 	</ul>
 </div>
 

--- a/spa2019/terms-and-conditions.html
+++ b/spa2019/terms-and-conditions.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2019/torgeir-dingsoyr.html
+++ b/spa2019/torgeir-dingsoyr.html
@@ -30,7 +30,7 @@
 
   <!--Button for booking now, is styled-->
   <a href="/spa2019/book-now.html" title="Book your place now"  class="cta">Book your place now</a>
-  <!--<h1 style="color: green;"><a href="https://spaconference.org/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
+  <!--<h1 style="color: green;"><a href="/scripts/makeproposal.php" class="cta">Submit a proposal for a session</a></h1>-->
 
   <nav>
 <ul>
@@ -39,7 +39,7 @@
     
     
 
-    <li><a href="https://www.spaconference.org/spa2019/programme.html">
+    <li><a href="/spa2019/programme.html">
       <span>Programme</span>
     </a></li>
   
@@ -95,7 +95,7 @@
     
     
 
-    <li><a href="https://spaconference.org/scripts/myprofile.php">
+    <li><a href="/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   


### PR DESCRIPTION
Previous PRs #1 and #2 didn't update all links, only programme and session pages.

This PR removes all remaining absolute links to spaconference.org from previous sites, whether www or not, whether http or https; all links are now relative.

The only remaining mention of the domain is in the README