### PR TITLE
Get rid of references to spaconference-history

### DIFF
--- a/spa2020/code-of-conduct.html
+++ b/spa2020/code-of-conduct.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2020/index.html
+++ b/spa2020/index.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2020/location.html
+++ b/spa2020/location.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2020/no-cookies.html
+++ b/spa2020/no-cookies.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2020/organisers.html
+++ b/spa2020/organisers.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2020/previous-conferences.html
+++ b/spa2020/previous-conferences.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   
@@ -87,29 +87,29 @@
     
       <nav>
         <ul>
-  <li><a href="http://spaconference-history.org/spa2019/"><span>SPA Software in Practice 2019</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2018/"><span>SPA Software in Practice 2018</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2017/"><span>SPA2017</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2016/"><span>SPA2016</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2015/"><span>SPA2015</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2014/"><span>SPA2014</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2013/"><span>SPA2013</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2012/"><span>SPA2012</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2011/"><span>SPA2011</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2010/"><span>SPA2010</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2009/"><span>SPA2009</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2008/"><span>SPA2008</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2007/"><span>SPA2007</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2006/"><span>SPA2006</span></a></li>
-  <li><a href="http://spaconference-history.org/spa2005/"><span>SPA2005</span></a></li>
-  <li><a href="http://spaconference-history.org/ot2004/"><span>OT2004</span></a></li>
-  <li><a href="http://spaconference-history.org/ot2003/"><span>OT2003</span></a></li>
-  <li><a href="http://spaconference-history.org/ot2002/"><span>OT2002</span></a></li>
-  <li><a href="http://spaconference-history.org/ot2001/"><span>OT2001</span></a></li>
-  <li><a href="http://spaconference-history.org/ot2000/index.htm"><span>OT2000</span></a></li>
-  <li><a href="http://spaconference-history.org/ot99/"><span>OT99</span></a></li>
-  <li><a href="http://spaconference-history.org/ot98/"><span>OT98</span></a></li>
-  <li><a href="http://spaconference-history.org/ot97/"><span>OT97</span></a></li>
+  <li><a href="http://spaconference.org/spa2019/"><span>SPA Software in Practice 2019</span></a></li>
+  <li><a href="http://spaconference.org/spa2018/"><span>SPA Software in Practice 2018</span></a></li>
+  <li><a href="http://spaconference.org/spa2017/"><span>SPA2017</span></a></li>
+  <li><a href="http://spaconference.org/spa2016/"><span>SPA2016</span></a></li>
+  <li><a href="http://spaconference.org/spa2015/"><span>SPA2015</span></a></li>
+  <li><a href="http://spaconference.org/spa2014/"><span>SPA2014</span></a></li>
+  <li><a href="http://spaconference.org/spa2013/"><span>SPA2013</span></a></li>
+  <li><a href="http://spaconference.org/spa2012/"><span>SPA2012</span></a></li>
+  <li><a href="http://spaconference.org/spa2011/"><span>SPA2011</span></a></li>
+  <li><a href="http://spaconference.org/spa2010/"><span>SPA2010</span></a></li>
+  <li><a href="http://spaconference.org/spa2009/"><span>SPA2009</span></a></li>
+  <li><a href="http://spaconference.org/spa2008/"><span>SPA2008</span></a></li>
+  <li><a href="http://spaconference.org/spa2007/"><span>SPA2007</span></a></li>
+  <li><a href="http://spaconference.org/spa2006/"><span>SPA2006</span></a></li>
+  <li><a href="http://spaconference.org/spa2005/"><span>SPA2005</span></a></li>
+  <li><a href="http://spaconference.org/ot2004/"><span>OT2004</span></a></li>
+  <li><a href="http://spaconference.org/ot2003/"><span>OT2003</span></a></li>
+  <li><a href="http://spaconference.org/ot2002/"><span>OT2002</span></a></li>
+  <li><a href="http://spaconference.org/ot2001/"><span>OT2001</span></a></li>
+  <li><a href="http://spaconference.org/ot2000/index.htm"><span>OT2000</span></a></li>
+  <li><a href="http://spaconference.org/ot99/"><span>OT99</span></a></li>
+  <li><a href="http://spaconference.org/ot98/"><span>OT98</span></a></li>
+  <li><a href="http://spaconference.org/ot97/"><span>OT97</span></a></li>
 </ul>
 
       </nav>

--- a/spa2020/programme_includes/header.html
+++ b/spa2020/programme_includes/header.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2020/programme_includes/person_header.html
+++ b/spa2020/programme_includes/person_header.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2020/programme_includes/session_header.html
+++ b/spa2020/programme_includes/session_header.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   

--- a/spa2020/terms-and-conditions.html
+++ b/spa2020/terms-and-conditions.html
@@ -64,7 +64,7 @@
     
     
 
-    <li><a href="http://spaconference-history.org/scripts/myprofile.php">
+    <li><a href="http://spaconference.org/scripts/myprofile.php">
       <span>My SPA</span>
     </a></li>
   


### PR DESCRIPTION
This was a temporary move; now moving back to the spaconference.org domain so removing all references to this.